### PR TITLE
chore(next16): clear viewport/sentry/eslint config deprecation warnings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,12 +17,14 @@ const bundleAnalyzer = withBundleAnalyzer({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  eslint: {
-    dirs: ['.'],
-  },
   poweredByHeader: false,
   reactStrictMode: true,
   serverExternalPackages: ['@electric-sql/pglite'],
+  turbopack: {
+    // Disambiguate the workspace root for Next 16 turbopack when a stray
+    // package-lock.json exists in a parent directory.
+    root: fileURLToPath(new URL('.', import.meta.url)),
+  },
   images: {
     // Allow external image sources
     remotePatterns: [
@@ -66,8 +68,11 @@ export default withSentryConfig(
     widenClientFileUpload: true,
     tunnelRoute: '/monitoring',
     hideSourceMaps: true,
-    disableLogger: true,
-    automaticVercelMonitors: true,
     telemetry: false,
+    webpack: {
+      // Sentry v10 moved these out of the top level into webpack.*
+      automaticVercelMonitors: true,
+      treeshake: { removeDebugLogging: true },
+    },
   },
 );

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import '@/styles/global.css';
 
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Poppins, Sorts_Mill_Goudy } from 'next/font/google';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
@@ -27,7 +27,6 @@ export const metadata: Metadata = {
   description: 'Agility Creative oferece soluções digitais inovadoras, incluindo desenvolvimento de sites, aplicativos, branding e marketing digital.',
   keywords: 'Agility Creative, soluções digitais, desenvolvimento web, branding, marketing digital',
   authors: [{ name: 'Agility Creative' }],
-  viewport: 'width=device-width, initial-scale=1.0',
   robots: {
     index: true,
     follow: true,
@@ -58,6 +57,11 @@ export const metadata: Metadata = {
     ],
     apple: '/assets/favicon/apple-touch-icon.png',
   },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
 };
 
 export function generateStaticParams() {


### PR DESCRIPTION
## Summary

Cleans up the deprecation warnings that started cluttering build logs after the Next 16 + Sentry 10 upgrade. No behavior changes — pure config / metadata reshape.

## Changes

### `src/app/[locale]/layout.tsx`

Next 14 → 15 moved `viewport` out of `Metadata` and into a sibling `Viewport` export. Build logs were spamming:

> ⚠ Unsupported metadata viewport is configured in metadata export in /[locale]. Please move it to viewport export instead.

Moved `viewport: 'width=device-width, initial-scale=1.0'` (string) into `export const viewport: Viewport = { width: 'device-width', initialScale: 1 }` (typed object).

### `next.config.mjs`

1. **Removed `eslint: { dirs: ['.'] }`** — Next 16 rejects the `eslint` key entirely now (`next lint` was removed; ESLint is run separately). Build was warning:
   > ⚠ Unrecognized key(s) in object: 'eslint'
2. **Added `turbopack.root`** — Next 16 turbopack was inferring the workspace root from a stray `package-lock.json` in `~/Desktop/`. Pinning the root to the project directory silences the warning.
3. **Sentry v10 config restructure** — moved `disableLogger` and `automaticVercelMonitors` out of `withSentryConfig`'s top-level options into the new `webpack` sub-key, matching Sentry v9+ docs. Build was logging:
   > [@sentry/nextjs] DEPRECATION WARNING: disableLogger is deprecated…
   > [@sentry/nextjs] DEPRECATION WARNING: automaticVercelMonitors is deprecated…

## Verification

- ✅ `npm run check-types` clean
- ✅ `npm run lint` 0 errors, 22 pre-existing warnings
- ✅ `npm test` 20 files / 69 tests pass
- ✅ `npm run build` compiles + lints + typechecks; **the four deprecation warnings above are gone from the build log**; only the env-dep Sanity failure remains
- ✅ Pre-push hook ran all of the above before this push

## Out of scope (separate follow-ups)

- **`middleware.ts` → `proxy.ts` rename** — Next 16 deprecated the file convention; backward-compat still works. Needs its own PR because the file name change has CI implications (worker config, Vercel build cache, etc.).
- The 1 remaining high CVE (`lodash` dev-only, disputed) is untouched.

## Test plan

- [ ] Pull, `npm run build` — confirm the four warnings are gone from your log
- [ ] Vercel preview deploys cleanly
- [ ] Manual: meta tags on the rendered page still include the `<meta name="viewport" ...>` (now generated by the new Viewport export, but content is identical)