### PR TITLE
chore(deps): upgrade zod to v4 and @hookform/resolvers to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@sanity/client": "^6.24.1",
         "@sentry/nextjs": "10.55.0",
         "@spotlightjs/spotlight": "^2.3.1",
-        "@t3-oss/env-nextjs": "^0.11.0",
+        "@t3-oss/env-nextjs": "0.13.11",
         "@tsparticles/react": "^3.0.0",
         "@tsparticles/slim": "^3.8.1",
         "@types/react-dom": "^19.2.3",
@@ -938,7 +938,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10021,35 +10020,57 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@t3-oss/env-nextjs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@t3-oss/env-nextjs/-/env-nextjs-0.11.1.tgz",
-      "integrity": "sha512-rx2XL9+v6wtOqLNJbD5eD8OezKlQD1BtC0WvvtHwBgK66jnF5+wGqtgkKK4Ygie1LVmoDClths2T4tdFmRvGrQ==",
+    "node_modules/@t3-oss/env-core": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-core/-/env-core-0.13.11.tgz",
+      "integrity": "sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==",
       "license": "MIT",
-      "dependencies": {
-        "@t3-oss/env-core": "0.11.1"
-      },
       "peerDependencies": {
+        "arktype": "^2.1.0",
         "typescript": ">=5.0.0",
-        "zod": "^3.0.0"
+        "valibot": "^1.0.0-beta.7 || ^1.0.0",
+        "zod": "^3.24.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
+        "arktype": {
+          "optional": true
+        },
         "typescript": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }
     },
-    "node_modules/@t3-oss/env-nextjs/node_modules/@t3-oss/env-core": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@t3-oss/env-core/-/env-core-0.11.1.tgz",
-      "integrity": "sha512-MaxOwEoG1ntCFoKJsS7nqwgcxLW1SJw238AJwfJeaz3P/8GtkxXZsPPolsz1AdYvUTbe3XvqZ/VCdfjt+3zmKw==",
+    "node_modules/@t3-oss/env-nextjs": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-nextjs/-/env-nextjs-0.13.11.tgz",
+      "integrity": "sha512-NC+3j7YWgpzdFu1t5y/8wqibTK0lm5RS4bjXA1n8uwik3wIR4iZM4Fa+U2BaMa5k3Qk8RZiYhoAIX0WogmGkzg==",
       "license": "MIT",
+      "dependencies": {
+        "@t3-oss/env-core": "0.13.11"
+      },
       "peerDependencies": {
+        "arktype": "^2.1.0",
         "typescript": ">=5.0.0",
-        "zod": "^3.0.0"
+        "valibot": "^1.0.0-beta.7 || ^1.0.0",
+        "zod": "^3.24.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
+        "arktype": {
+          "optional": true
+        },
         "typescript": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@clerk/nextjs": "^7.4.2",
         "@designbycode/tailwindcss-text-stroke": "^1.3.0",
         "@electric-sql/pglite": "^0.2.2",
-        "@hookform/resolvers": "^3.9.0",
+        "@hookform/resolvers": "5.4.0",
         "@logtail/pino": "^0.5.0",
         "@portabletext/react": "^3.2.0",
         "@react-spring/web": "^10.1.0",
@@ -37,7 +37,7 @@
         "react-icons": "^5.3.0",
         "sharp": "^0.33.5",
         "tailwind-merge": "^2.5.2",
-        "zod": "^3.23.8"
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^2.26.0",
@@ -2650,16 +2650,6 @@
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@eslint-react/kit/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@eslint-react/shared": {
       "version": "1.53.1",
       "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-1.53.1.tgz",
@@ -2675,16 +2665,6 @@
       },
       "engines": {
         "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@eslint-react/shared/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@eslint-react/var": {
@@ -3005,12 +2985,15 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
-      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
       "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -9270,6 +9253,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@storybook/addon-docs": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.1.tgz",
@@ -10032,11 +10021,14 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@t3-oss/env-core": {
+    "node_modules/@t3-oss/env-nextjs": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@t3-oss/env-core/-/env-core-0.11.1.tgz",
-      "integrity": "sha512-MaxOwEoG1ntCFoKJsS7nqwgcxLW1SJw238AJwfJeaz3P/8GtkxXZsPPolsz1AdYvUTbe3XvqZ/VCdfjt+3zmKw==",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-nextjs/-/env-nextjs-0.11.1.tgz",
+      "integrity": "sha512-rx2XL9+v6wtOqLNJbD5eD8OezKlQD1BtC0WvvtHwBgK66jnF5+wGqtgkKK4Ygie1LVmoDClths2T4tdFmRvGrQ==",
       "license": "MIT",
+      "dependencies": {
+        "@t3-oss/env-core": "0.11.1"
+      },
       "peerDependencies": {
         "typescript": ">=5.0.0",
         "zod": "^3.0.0"
@@ -10047,14 +10039,11 @@
         }
       }
     },
-    "node_modules/@t3-oss/env-nextjs": {
+    "node_modules/@t3-oss/env-nextjs/node_modules/@t3-oss/env-core": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@t3-oss/env-nextjs/-/env-nextjs-0.11.1.tgz",
-      "integrity": "sha512-rx2XL9+v6wtOqLNJbD5eD8OezKlQD1BtC0WvvtHwBgK66jnF5+wGqtgkKK4Ygie1LVmoDClths2T4tdFmRvGrQ==",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-core/-/env-core-0.11.1.tgz",
+      "integrity": "sha512-MaxOwEoG1ntCFoKJsS7nqwgcxLW1SJw238AJwfJeaz3P/8GtkxXZsPPolsz1AdYvUTbe3XvqZ/VCdfjt+3zmKw==",
       "license": "MIT",
-      "dependencies": {
-        "@t3-oss/env-core": "0.11.1"
-      },
       "peerDependencies": {
         "typescript": ">=5.0.0",
         "zod": "^3.0.0"
@@ -37756,9 +37745,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@sanity/client": "^6.24.1",
     "@sentry/nextjs": "10.55.0",
     "@spotlightjs/spotlight": "^2.3.1",
-    "@t3-oss/env-nextjs": "^0.11.0",
+    "@t3-oss/env-nextjs": "0.13.11",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.8.1",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@clerk/nextjs": "^7.4.2",
     "@designbycode/tailwindcss-text-stroke": "^1.3.0",
     "@electric-sql/pglite": "^0.2.2",
-    "@hookform/resolvers": "^3.9.0",
+    "@hookform/resolvers": "5.4.0",
     "@logtail/pino": "^0.5.0",
     "@portabletext/react": "^3.2.0",
     "@react-spring/web": "^10.1.0",
@@ -56,7 +56,7 @@
     "react-icons": "^5.3.0",
     "sharp": "^0.33.5",
     "tailwind-merge": "^2.5.2",
-    "zod": "^3.23.8"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.26.0",


### PR DESCRIPTION
## Summary

Bumps `zod` from `^3.23.8` to `4.4.3` and `@hookform/resolvers` from `^3.9.0` to `5.4.0` (its companion package required for Zod 4 peer compatibility).

The codebase only uses a tiny surface of Zod (`z.object`, `z.string().min(1)`, `z.string().optional()`, `z.coerce.number()`, `z.enum`) — all of which are 100% source-compatible across v3 → v4. **Zero code changes required.**

## Files using Zod (all kept as-is)

- `src/libs/Env.ts` — T3 env schema (server/client/shared blocks)
- `src/validations/GuestbookValidation.ts` — Guestbook create/edit/delete schemas
- `src/components/GuestbookForm.tsx` — `zodResolver(GuestbookValidation)` for `react-hook-form`

## Why now

- `zod` v4 ships with significant bundle-size and runtime-perf improvements (the v4 announcement quotes ~3x faster parsing for typical schemas)
- `@hookform/resolvers` v3 still works with Zod v3 but doesn't carry Zod 4 typings; v5 is the version aligned with both `react-hook-form` ≥ 7.55 (we're on 7.76) and `zod` 4
- It clears the last non-trivial outstanding dep major in the project

## Verification

- ✅ `npm install` clean (no peer conflicts)
- ✅ `npm run check-types` clean
- ✅ `npm test` 20 files / 69 tests pass
- ✅ `npm run build` compiles + lints + typechecks; only the env-dep Sanity failure remains
- ✅ Pre-push hook ran all of the above
- ✅ `npm audit` unchanged: 0 critical, 1 high (dev-only lodash), 17 moderate

## Test plan

- [ ] Pull, `npm install`, `npm run build` with real env vars
- [ ] Manually visit `/[locale]/boilerplate/guestbook` on the preview deploy — Guestbook form is the only place that uses `zodResolver`. Confirm submit validation still works (form blocks empty fields, accepts valid input)
- [ ] CI: Vercel + workflow checks green