### PR TITLE
feat(blog): light-themed blog with category routes, AI-agent content API, and tests

### DIFF
--- a/.env
+++ b/.env
@@ -13,4 +13,7 @@ NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
 ######## After creating the file, you can add the following variables.
 # Clerk authentication
 CLERK_SECRET_KEY=your_clerk_secret_key
+# Blog API — bearer token for /api/blog (32-char MD5 hex). Generate with:
+#   node -e "console.log(require('crypto').createHash('md5').update(require('crypto').randomBytes(32)).digest('hex'))"
+BLOG_API_TOKEN=your_blog_api_token_md5_hex
 ######## [END] SENSITIVE DATA

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,0 +1,202 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import { getTranslations } from 'next-intl/server';
+
+import { BlogArticleBody, BlogHero } from '@/components/blog';
+import blogData from '@/data/blog.json';
+import { Link } from '@/libs/i18nNavigation';
+import type { BlogPost } from '@/types/blog';
+import { AppConfig } from '@/utils/AppConfig';
+import { getBaseUrl } from '@/utils/Helpers';
+import { buildAlternates, localizedUrl, ogAlternateLocales, ogLocale } from '@/utils/seo';
+
+type Params = {
+  slug: string;
+  locale: string;
+};
+
+const posts = blogData as BlogPost[];
+
+export async function generateStaticParams() {
+  return posts.map(post => ({ slug: post.slug }));
+}
+
+export async function generateMetadata(props: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { slug, locale } = await props.params;
+  const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
+    ? (locale as (typeof AppConfig.locales)[number])
+    : AppConfig.defaultLocale;
+  const post = posts.find(item => item.slug === slug);
+  const alternates = buildAlternates(safeLocale, `/blog/${slug}`);
+  const title = post?.title ?? slug;
+  const description = post?.excerpt ?? '';
+  const ogImage = post?.coverImage;
+
+  return {
+    metadataBase: new URL(getBaseUrl()),
+    title,
+    description,
+    keywords: post?.tags,
+    authors: post?.author?.name ? [{ name: post.author.name }] : undefined,
+    alternates,
+    openGraph: {
+      title,
+      description,
+      url: alternates.canonical,
+      siteName: AppConfig.name,
+      locale: ogLocale(safeLocale),
+      alternateLocale: ogAlternateLocales(safeLocale),
+      type: 'article',
+      publishedTime: post?.publishedAt,
+      modifiedTime: post?.updatedAt ?? post?.publishedAt,
+      authors: post?.author?.name ? [post.author.name] : undefined,
+      tags: post?.tags,
+      images: ogImage ? [{ url: ogImage, alt: post?.coverAlt ?? title }] : undefined,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ogImage ? [ogImage] : undefined,
+    },
+  };
+}
+
+const BlogArticlePage = async (props: { params: Promise<Params> }) => {
+  const { slug, locale } = await props.params;
+  const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
+    ? (locale as (typeof AppConfig.locales)[number])
+    : AppConfig.defaultLocale;
+  const t = await getTranslations('BlogDetail');
+  const post = posts.find(item => item.slug === slug);
+
+  if (!post) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <p className="text-base text-neutral-500">{t('notFound')}</p>
+      </div>
+    );
+  }
+
+  const dateLabel = new Intl.DateTimeFormat(safeLocale === 'pt-BR' ? 'pt-BR' : 'en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(post.publishedAt));
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    'headline': post.title,
+    'description': post.excerpt,
+    'image': post.coverImage,
+    'datePublished': post.publishedAt,
+    'dateModified': post.updatedAt ?? post.publishedAt,
+    'author': post.author
+      ? { '@type': 'Person', 'name': post.author.name }
+      : undefined,
+    'mainEntityOfPage': {
+      '@type': 'WebPage',
+      '@id': localizedUrl(safeLocale, `/blog/${slug}`),
+    },
+  };
+
+  const heroMeta = (
+    <>
+      {post.author?.avatar && (
+        <span className="relative inline-flex size-7 overflow-hidden rounded-full border border-neutral-200 bg-neutral-50">
+          <Image
+            src={post.author.avatar}
+            alt={post.author.name}
+            fill
+            sizes="28px"
+            className="object-contain p-1.5"
+          />
+        </span>
+      )}
+      {post.author && (
+        <span className="font-medium text-neutral-700">{post.author.name}</span>
+      )}
+      <span aria-hidden className="text-neutral-300">·</span>
+      <time dateTime={post.publishedAt}>{dateLabel}</time>
+      {post.readingTimeMinutes && (
+        <>
+          <span aria-hidden className="text-neutral-300">·</span>
+          <span>
+            {post.readingTimeMinutes}
+            {' '}
+            {t('readingTimeSuffix')}
+          </span>
+        </>
+      )}
+    </>
+  );
+
+  return (
+    <>
+      <BlogHero
+        eyebrow={post.category}
+        title={post.title}
+        subtitle={post.excerpt}
+        meta={heroMeta}
+        breadcrumbs={[
+          { label: t('breadcrumbBlog'), href: '/blog' },
+          { label: post.title },
+        ]}
+      />
+
+      <article className="mx-auto max-w-[680px] px-4 py-16 sm:px-6 md:py-20">
+        {post.coverImage && (
+          <figure className="mb-12 overflow-hidden rounded-xl border border-neutral-200">
+            <Image
+              src={post.coverImage}
+              alt={post.coverAlt ?? post.title}
+              width={1600}
+              height={900}
+              sizes="(max-width: 768px) 100vw, 680px"
+              priority
+              className="h-auto w-full"
+            />
+          </figure>
+        )}
+
+        <BlogArticleBody blocks={post.body} />
+
+        {post.tags && post.tags.length > 0 && (
+          <div className="mt-16 flex flex-wrap gap-2 border-t border-neutral-200 pt-8">
+            {post.tags.map(tag => (
+              <span
+                key={tag}
+                className="rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1 text-xs text-neutral-500"
+              >
+                #
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-12 border-t border-neutral-200 pt-8">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 text-sm font-medium text-neutral-600 transition-colors hover:text-neutral-900"
+          >
+            <span aria-hidden>←</span>
+            {' '}
+            {t('backToBlog')}
+          </Link>
+        </div>
+      </article>
+
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/dom-no-dangerously-set-innerhtml
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </>
+  );
+};
+
+export default BlogArticlePage;

--- a/src/app/[locale]/blog/category/[slug]/page.tsx
+++ b/src/app/[locale]/blog/category/[slug]/page.tsx
@@ -1,0 +1,163 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+
+import type { BlogCardItem } from '@/components/blog';
+import {
+  BlogHero,
+  BlogIndex,
+  findCategoryBySlug,
+  getAllCategorySlugs,
+  getOrderedCategories,
+  slugifyCategory,
+} from '@/components/blog';
+import blogData from '@/data/blog.json';
+import type { BlogPost } from '@/types/blog';
+import { AppConfig } from '@/utils/AppConfig';
+import { getBaseUrl } from '@/utils/Helpers';
+import { buildAlternates, localizedUrl, ogAlternateLocales, ogLocale } from '@/utils/seo';
+
+type Params = {
+  slug: string;
+  locale: string;
+};
+
+const posts = blogData as BlogPost[];
+
+export function generateStaticParams() {
+  return getAllCategorySlugs(posts).map(slug => ({ slug }));
+}
+
+export async function generateMetadata(props: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { slug, locale } = await props.params;
+  const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
+    ? (locale as (typeof AppConfig.locales)[number])
+    : AppConfig.defaultLocale;
+  const category = findCategoryBySlug(posts, slug);
+  const t = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
+  const alternates = buildAlternates(safeLocale, `/blog/category/${slug}`);
+
+  if (!category) {
+    return {
+      metadataBase: new URL(getBaseUrl()),
+      title: t('notFound'),
+      alternates,
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const title = `${t('titlePrefix')} ${category.label}`.trim();
+  const description = t('metaDescription', { category: category.label });
+
+  return {
+    metadataBase: new URL(getBaseUrl()),
+    title,
+    description,
+    keywords: [category.label, 'blog', 'agility creative'],
+    alternates,
+    openGraph: {
+      title,
+      description,
+      url: alternates.canonical,
+      siteName: AppConfig.name,
+      locale: ogLocale(safeLocale),
+      alternateLocale: ogAlternateLocales(safeLocale),
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+  };
+}
+
+const BlogCategoryPage = async (props: { params: Promise<Params> }) => {
+  const { slug, locale } = await props.params;
+  const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
+    ? (locale as (typeof AppConfig.locales)[number])
+    : AppConfig.defaultLocale;
+  const category = findCategoryBySlug(posts, slug);
+
+  if (!category) {
+    notFound();
+  }
+
+  const tBlog = await getTranslations('BlogPage');
+  const tCategory = await getTranslations('BlogCategory');
+
+  const sortedPosts = [...posts]
+    .filter(post => post.category && slugifyCategory(post.category) === slug)
+    .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+
+  const items: BlogCardItem[] = sortedPosts.map(post => ({
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    coverImage: post.coverImage,
+    coverAlt: post.coverAlt,
+    category: post.category,
+    publishedAt: post.publishedAt,
+    readingTimeMinutes: post.readingTimeMinutes,
+  }));
+
+  const categories = getOrderedCategories(posts);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    'name': `${tCategory('titlePrefix')} ${category.label}`,
+    'description': tCategory('metaDescription', { category: category.label }),
+    'url': localizedUrl(safeLocale, `/blog/category/${slug}`),
+    'inLanguage': safeLocale,
+    'mainEntity': {
+      '@type': 'ItemList',
+      'itemListElement': items.map((item, index) => ({
+        '@type': 'ListItem',
+        'position': index + 1,
+        'url': localizedUrl(safeLocale, `/blog/${item.slug}`),
+        'name': item.title,
+      })),
+    },
+  };
+
+  return (
+    <>
+      <BlogHero
+        eyebrow={`${tCategory('eyebrowPrefix')} · ${category.label}`}
+        title={(
+          <>
+            {tCategory('titlePrefix')}
+            {' '}
+            <span className="text-primary">{category.label}</span>
+          </>
+        )}
+        subtitle={tCategory('subtitle', { category: category.label })}
+        breadcrumbs={[
+          { label: tCategory('breadcrumbBlog'), href: '/blog' },
+          { label: category.label },
+        ]}
+      />
+
+      <BlogIndex
+        items={items}
+        categories={categories}
+        activeSlug={slug}
+        locale={locale}
+        allLabel={tBlog('allLabel')}
+        readArticleLabel={tBlog('readArticle')}
+        emptyLabel={tBlog('empty')}
+      />
+
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/dom-no-dangerously-set-innerhtml
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </>
+  );
+};
+
+export default BlogCategoryPage;

--- a/src/app/[locale]/blog/layout.tsx
+++ b/src/app/[locale]/blog/layout.tsx
@@ -1,0 +1,17 @@
+import { setRequestLocale } from 'next-intl/server';
+
+import BlogTemplate from '@/templates/BlogTemplate';
+
+export default async function Layout(
+  props: {
+    children: React.ReactNode;
+    params: Promise<{ locale: string }>;
+  },
+) {
+  setRequestLocale((await props.params).locale);
+  return (
+    <BlogTemplate>
+      {props.children}
+    </BlogTemplate>
+  );
+}

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+
+import type { BlogCardItem } from '@/components/blog';
+import { BlogHero, BlogIndex, getOrderedCategories } from '@/components/blog';
+import blogData from '@/data/blog.json';
+import type { BlogPost } from '@/types/blog';
+import { AppConfig } from '@/utils/AppConfig';
+import { getBaseUrl } from '@/utils/Helpers';
+import { buildAlternates, localizedUrl, ogAlternateLocales, ogLocale } from '@/utils/seo';
+
+const BLOG_PATH = '/blog';
+
+const posts = blogData as BlogPost[];
+
+export async function generateMetadata(props: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await props.params;
+  const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
+    ? (locale as (typeof AppConfig.locales)[number])
+    : AppConfig.defaultLocale;
+  const t = await getTranslations({ locale: safeLocale, namespace: 'BlogPage' });
+  const alternates = buildAlternates(safeLocale, BLOG_PATH);
+  const title = `${t('titlePrefix')} ${t('titleHighlight')}`.trim();
+
+  return {
+    metadataBase: new URL(getBaseUrl()),
+    title,
+    description: t('subtitle'),
+    keywords: ['product', 'design', 'engineering', 'agility creative', 'blog'],
+    alternates,
+    openGraph: {
+      title,
+      description: t('subtitle'),
+      url: alternates.canonical,
+      siteName: AppConfig.name,
+      locale: ogLocale(safeLocale),
+      alternateLocale: ogAlternateLocales(safeLocale),
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: t('subtitle'),
+    },
+  };
+}
+
+const BlogPage = async (props: { params: Promise<{ locale: string }> }) => {
+  const { locale } = await props.params;
+  const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
+    ? (locale as (typeof AppConfig.locales)[number])
+    : AppConfig.defaultLocale;
+  const t = await getTranslations('BlogPage');
+
+  const sortedPosts = [...posts].sort(
+    (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+  );
+
+  const items: BlogCardItem[] = sortedPosts.map(post => ({
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    coverImage: post.coverImage,
+    coverAlt: post.coverAlt,
+    category: post.category,
+    publishedAt: post.publishedAt,
+    readingTimeMinutes: post.readingTimeMinutes,
+  }));
+
+  const categories = getOrderedCategories(sortedPosts);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    'name': `Agility Creative — ${t('titlePrefix')} ${t('titleHighlight')}`,
+    'description': t('subtitle'),
+    'url': localizedUrl(safeLocale, BLOG_PATH),
+    'inLanguage': safeLocale,
+    'blogPost': items.map(item => ({
+      '@type': 'BlogPosting',
+      'headline': item.title,
+      'description': item.excerpt,
+      'datePublished': item.publishedAt,
+      'url': localizedUrl(safeLocale, `/blog/${item.slug}`),
+      'image': item.coverImage,
+    })),
+  };
+
+  return (
+    <>
+      <BlogHero
+        eyebrow={t('badge')}
+        title={(
+          <>
+            {t('titlePrefix')}
+            {' '}
+            <span className="text-primary">{t('titleHighlight')}</span>
+          </>
+        )}
+        subtitle={t('subtitle')}
+      />
+
+      <BlogIndex
+        items={items}
+        categories={categories}
+        locale={locale}
+        allLabel={t('allLabel')}
+        readArticleLabel={t('readArticle')}
+        emptyLabel={t('empty')}
+      />
+
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/dom-no-dangerously-set-innerhtml
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </>
+  );
+};
+
+export default BlogPage;

--- a/src/app/api/blog/context.md
+++ b/src/app/api/blog/context.md
@@ -1,0 +1,355 @@
+# Agility Blog API — agent reference
+
+A single authenticated HTTP endpoint that lets AI agents manage blog articles published on `agilitycreative.com/blog`. Every operation goes through one POST request whose `action` field picks the verb.
+
+- **Endpoint**: `POST /api/blog`
+- **Content-Type**: `application/json`
+- **Auth**: `Authorization: Bearer <BLOG_API_TOKEN>` (32-char MD5 hex)
+- **Runtime**: Node.js (the route writes to the local filesystem — do not deploy to a read-only serverless runtime without swapping the storage layer)
+- **Storage**: `src/data/blog.json` — flat JSON array, newest first. Reads and writes are atomic (`write → rename`), but there is **no concurrent-write locking**. Treat the API as single-writer.
+
+---
+
+## 1. Authentication
+
+Every request must include:
+
+```
+Authorization: Bearer <token>
+```
+
+Where `<token>` matches the `BLOG_API_TOKEN` environment variable on the server (32-char MD5 hex, e.g. `82b5ddb63bdd02041caaf642fac11d01`).
+
+Comparison is constant-time. Anything else returns:
+
+```http
+HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+
+{ "ok": false, "error": "unauthorized" }
+```
+
+### Rotating the token
+
+1. Generate a fresh MD5:
+   ```bash
+   node -e "console.log(require('crypto').createHash('md5').update(require('crypto').randomBytes(32)).digest('hex'))"
+   ```
+2. Replace `BLOG_API_TOKEN` in `.env.local` (dev) or your hosting env (prod).
+3. Restart the server. Distribute the new token to every agent.
+
+---
+
+## 2. Common response envelope
+
+```ts
+type Ok<T> = { ok: true; data: T };
+type Err = { ok: false; error: string; details?: unknown };
+```
+
+| HTTP | When it happens |
+|------|-----------------|
+| 200  | `list`, `read`, `update` success |
+| 201  | `create` success |
+| 400  | `invalid_json` (body wasn't JSON) or `invalid_request` (zod validation failed — see `details.fieldErrors`) |
+| 401  | Missing/wrong bearer token |
+| 404  | `not_found` (read/update with unknown slug) |
+| 409  | `slug_conflict` on create (a post with the same slug already exists) |
+| 500  | `storage_read_failed` / `storage_write_failed` — the JSON file couldn't be read/written |
+
+---
+
+## 3. Actions
+
+The request body is always `{ "action": "...", ...payload }`. The `action` field discriminates which payload is expected.
+
+### 3.1 `list` — paginate posts
+
+Returns a paginated, newest-first summary list. Bodies are **not** included to keep responses small.
+
+**Request fields**
+
+| Field          | Type                  | Notes |
+|----------------|-----------------------|-------|
+| `categorySlug` | `string?`             | Filter by category slug (e.g. `inteligencia-artificial`). Slugs come from `slugifyCategory(category)`. |
+| `category`     | `string?`             | Filter by exact category label (e.g. `"Inteligência Artificial"`). Ignored if `categorySlug` is set. |
+| `limit`        | `number?` (1–100)     | Default = all matching posts. |
+| `offset`       | `number?` (≥0)        | Default = 0. |
+
+**Response data**
+
+```ts
+{
+  total: number; // total posts matching the filter (pre-paging)
+  count: number; // posts returned in this page
+  offset: number;
+  limit: number;
+  posts: Array<{
+    slug: string;
+    title: string;
+    excerpt: string;
+    category?: string;
+    publishedAt: string; // YYYY-MM-DD
+    updatedAt?: string;
+    readingTimeMinutes?: number;
+    coverImage?: string;
+  }>;
+}
+```
+
+**Example**
+
+```bash
+curl -s -X POST https://agilitycreative.com/api/blog \
+  -H "Authorization: Bearer $BLOG_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"list","categorySlug":"inteligencia-artificial","limit":10}'
+```
+
+---
+
+### 3.2 `read` — fetch one post (full body)
+
+**Request fields**
+
+| Field  | Type     | Notes |
+|--------|----------|-------|
+| `slug` | `string` | Required. Matches the regex `^[a-z0-9]+(?:-[a-z0-9]+)*$`. |
+
+**Response data**
+
+```ts
+{ post: BlogPost; } // full post including the body block array
+```
+
+**Errors**: `404 not_found` if no post matches.
+
+**Example**
+
+```bash
+curl -s -X POST https://agilitycreative.com/api/blog \
+  -H "Authorization: Bearer $BLOG_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"read","slug":"mvp-em-30-dias-o-que-cabe-e-o-que-nao-cabe"}'
+```
+
+---
+
+### 3.3 `create` — publish a new article
+
+**Request fields**
+
+```ts
+{
+  action: 'create';
+  post: BlogPostInput;
+}
+```
+
+`BlogPostInput`:
+
+| Field                | Type                                        | Required | Notes |
+|----------------------|---------------------------------------------|----------|-------|
+| `slug`               | `string` `(^[a-z0-9]+(?:-[a-z0-9]+)*$)`     | ❌       | Auto-derived from `title` if omitted. Must be globally unique — 409 otherwise. |
+| `title`              | `string` (3–200)                            | ✅       | |
+| `excerpt`            | `string` (10–500)                           | ✅       | Shown in the card grid + meta description + OG description. Write it as standalone marketing copy. |
+| `coverImage`         | `string` (absolute URL or `/…` path)        | ❌       | 1600×900 recommended for the featured-card hero. |
+| `coverAlt`           | `string`                                    | ❌       | Image alt — required for accessibility if `coverImage` is set in a real post. |
+| `publishedAt`        | `YYYY-MM-DD` or ISO 8601                    | ❌       | Defaults to today (UTC). |
+| `updatedAt`          | `YYYY-MM-DD` or ISO 8601                    | ❌       | |
+| `readingTimeMinutes` | `number` (1–120)                            | ❌       | Auto-computed from `body` (~200 wpm) if omitted. |
+| `category`           | `string` (1–60)                             | ❌       | Free-form label. The slug used in `/blog/category/<slug>` URLs is derived automatically via `slugifyCategory()`. Reuse existing labels exactly to land posts under the same tab. |
+| `tags`               | `string[]` (max 20, each 1–40 chars)        | ❌       | Plain words — no `#`. |
+| `author`             | `{ name, role?, avatar? }`                  | ❌       | `avatar` can be an absolute URL or `/…` path. |
+| `body`               | `BlogBodyBlock[]` (min 1)                   | ✅       | See §4. |
+
+**Response**: `201 Created` with the canonical stored post (slug, defaults, computed reading time) under `data.post`.
+
+**Errors**:
+- `400 invalid_request` — zod validation failures, `details.fieldErrors` says what's wrong per field.
+- `400 invalid_slug` — title slugified to empty (e.g. emoji-only title).
+- `409 slug_conflict` — a post with that slug already exists. Use `update` instead.
+
+---
+
+### 3.4 `update` — edit an existing article
+
+**Request fields**
+
+```ts
+{
+  action: 'update';
+  slug: string; // identifies the post; cannot be changed
+  patch: Partial<BlogPostInput>;
+}
+```
+
+Notes:
+
+- **`slug` inside `patch` is rejected** — slugs are URLs and must stay stable for SEO.
+- `updatedAt` is **always** overwritten with today's date, even if the caller sets it.
+- If `body` is included in the patch, `readingTimeMinutes` is recomputed unless explicitly provided.
+- Fields not present in `patch` are left untouched.
+
+**Response data**: `{ post: BlogPost }` — the merged record.
+
+**Errors**: `404 not_found` if no post matches the slug.
+
+---
+
+## 4. Body block format
+
+`body` is an ordered list of typed blocks. Each block renders to a specific element on `/blog/<slug>`. The renderer lives in `src/components/blog/BlogArticleBody.tsx` — keep that file as the source of truth for visual output.
+
+| `type`      | Required fields                                  | Optional                  | Renders as |
+|-------------|--------------------------------------------------|---------------------------|------------|
+| `paragraph` | `text: string`                                   | —                         | `<p>` |
+| `heading`   | `level: 2 \| 3`, `text: string`                  | —                         | `<h2>` / `<h3>` |
+| `list`      | `items: string[]` (min 1)                        | `ordered?: boolean`       | `<ul>` or `<ol>` |
+| `quote`     | `text: string`                                   | `cite?: string`           | Stylized `<blockquote>` |
+| `image`     | `src: string` (URL or `/…`), `alt: string`       | `caption?: string`        | `<figure>` with `<Image>` |
+| `code`      | `code: string`                                   | `language?: string`       | Monospaced `<pre><code>` block. Language is metadata only — no syntax highlighting yet. |
+
+Block ordering rules of thumb:
+
+1. Open with one `paragraph` (the lede). The `excerpt` is shown separately above — don't repeat it verbatim.
+2. Group content under `heading` level 2; reserve level 3 for sub-sections.
+3. Lists work best after a short setup paragraph.
+
+### Minimal example
+
+```json
+{
+  "action": "create",
+  "post": {
+    "title": "O que mudou com Claude 4.7 para devs",
+    "excerpt": "Resumo prático: contexto de 1M, melhor uso de ferramentas, e o que isso muda no fluxo de quem programa todo dia.",
+    "category": "Inteligência Artificial",
+    "coverImage": "https://placehold.co/1600x900/0a0a0a/4F46E5/png?text=Claude+4.7",
+    "coverAlt": "Logo do Claude com fundo gradiente",
+    "tags": ["ia", "claude", "ferramentas"],
+    "author": { "name": "Equipe Agility", "role": "Editorial" },
+    "body": [
+      { "type": "paragraph", "text": "A nova geração trouxe contexto de 1 milhão de tokens..." },
+      { "type": "heading", "level": 2, "text": "Contexto longo" },
+      { "type": "paragraph", "text": "Você agora pode despejar um repositório inteiro..." },
+      {
+        "type": "list",
+        "ordered": true,
+        "items": [
+          "Quando o contexto longo paga",
+          "Quando RAG ainda é a resposta certa",
+          "O que muda no custo por requisição"
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 5. Categories & SEO knock-on effects
+
+Creating or updating a post can have ripple effects you should be aware of:
+
+- **`category` becomes a tab on `/blog`** and an SEO page at `/blog/category/<slug>`. The first time a new label appears (e.g. `"Inteligência Artificial"`), it instantly spawns `/blog/category/inteligencia-artificial`, gets listed in the sitemap on the next request, and shows up in the navbar tabs.
+- Reuse **existing labels verbatim** to avoid creating near-duplicate categories. List the current labels with `list` (the response's `posts[].category` field).
+- **Slug stability is sacred**: once a post exists, its URL is `/blog/<slug>` (often indexed). The API refuses to change `slug` on update for that reason. If you genuinely need to rename, ask a human — they'll need to add an HTTP redirect.
+- **Locale alternates** (`hreflang`) are emitted automatically for every post — the same record serves both `/blog/<slug>` and `/en/blog/<slug>`. Write the post in the language that matches your audience; the platform doesn't translate.
+
+---
+
+## 6. Error reference
+
+| `error` value            | HTTP | Meaning |
+|--------------------------|------|---------|
+| `unauthorized`           | 401  | Missing or wrong bearer token. |
+| `invalid_json`           | 400  | Request body wasn't valid JSON. |
+| `invalid_request`        | 400  | Zod validation failed. Inspect `details.fieldErrors` for per-field issues. |
+| `invalid_slug`           | 400  | Auto-generated slug came out empty (e.g. title was emoji-only). Provide an explicit `slug`. |
+| `not_found`              | 404  | No post matches the requested slug. `details.slug` echoes the input. |
+| `slug_conflict`          | 409  | Tried to create a post whose slug already exists. Switch to `update`. |
+| `storage_read_failed`    | 500  | Couldn't read `blog.json`. Check file permissions / disk. |
+| `storage_write_failed`   | 500  | Couldn't write `blog.json`. Same. |
+
+---
+
+## 7. Worked end-to-end example (Node)
+
+```js
+const TOKEN = process.env.BLOG_API_TOKEN;
+const BASE = 'https://agilitycreative.com/api/blog';
+
+const call = async (payload) => {
+  const res = await fetch(BASE, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  const json = await res.json();
+  if (!json.ok) {
+    throw new Error(`${res.status} ${json.error}: ${JSON.stringify(json.details ?? {})}`);
+  }
+  return json.data;
+};
+
+// 1. List current AI posts to avoid title overlap
+const { posts } = await call({ action: 'list', categorySlug: 'inteligencia-artificial' });
+
+// 2. Publish
+const { post } = await call({
+  action: 'create',
+  post: {
+    title: 'Tutorial: rodando Claude na sua CLI em 5 minutos',
+    excerpt: 'Passo-a-passo curto para começar a usar a Claude API no terminal, sem framework.',
+    category: 'Inteligência Artificial',
+    tags: ['ia', 'cli', 'tutorial'],
+    body: [
+      { type: 'paragraph', text: '...' },
+      { type: 'heading', level: 2, text: 'Instalar a CLI' },
+      { type: 'code', language: 'bash', code: 'npm i -g @anthropic-ai/sdk' },
+    ],
+  },
+});
+
+// 3. Later: add a follow-up paragraph
+await call({
+  action: 'update',
+  slug: post.slug,
+  patch: {
+    body: [
+      ...post.body,
+      { type: 'paragraph', text: 'Atualização (junho/2026): suporte oficial ao modelo Haiku 4.5.' },
+    ],
+  },
+});
+```
+
+---
+
+## 8. Operational caveats
+
+- **Filesystem backing**: edits land in `src/data/blog.json` in the running server's working directory. On Vercel / AWS Lambda / Cloudflare Workers this won't persist across deploys or invocations. Plan to swap `readPosts` / `writePosts` for a real datastore (Postgres, Sanity, KV) before scaling.
+- **No revision history**: updates overwrite in place. If you need rollback, snapshot `blog.json` before bulk operations.
+- **No drafts / scheduling**: the moment `create` returns 201, the post is live at `/blog/<slug>` and listed in the sitemap.
+- **No delete**: by design. To pull a post you have to edit `blog.json` by hand and add a 410 (or rewrite) at the server level so search engines de-index.
+- **Single-writer**: the route writes the whole file. Concurrent writes from two agents will race and the last writer wins (other changes lost). Serialize agent calls if you batch.
+
+---
+
+## 9. Quick local test
+
+```bash
+# in repo root
+TOKEN=$(grep BLOG_API_TOKEN .env.local | cut -d= -f2)
+curl -s -X POST http://localhost:3000/api/blog \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"list","limit":1}' | jq .
+```
+
+Expected: `{ "ok": true, "data": { "total": N, ... } }`.

--- a/src/app/api/blog/route.test.ts
+++ b/src/app/api/blog/route.test.ts
@@ -1,0 +1,320 @@
+import fs from 'node:fs/promises';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BlogPost } from '@/types/blog';
+
+import { POST } from './route';
+
+vi.mock('node:fs/promises', () => {
+  const readFile = vi.fn();
+  const writeFile = vi.fn();
+  const rename = vi.fn();
+  return {
+    default: { readFile, writeFile, rename },
+    readFile,
+    writeFile,
+    rename,
+  };
+});
+
+const TOKEN = '11111111111111111111111111111111';
+
+const samplePosts = (): BlogPost[] => [
+  {
+    slug: 'post-a',
+    title: 'Post A',
+    excerpt: 'Excerpt A long enough',
+    publishedAt: '2026-05-01',
+    category: 'Produto',
+    body: [{ type: 'paragraph', text: 'paragraph a' }],
+  },
+  {
+    slug: 'post-b',
+    title: 'Post B',
+    excerpt: 'Excerpt B long enough',
+    publishedAt: '2026-04-01',
+    category: 'Design',
+    body: [{ type: 'paragraph', text: 'paragraph b' }],
+  },
+  {
+    slug: 'post-c',
+    title: 'Post C',
+    excerpt: 'Excerpt C long enough',
+    publishedAt: '2026-03-01',
+    category: 'Inteligência Artificial',
+    body: [{ type: 'paragraph', text: 'paragraph c' }],
+  },
+];
+
+const buildRequest = (
+  body: unknown,
+  { token = TOKEN, raw }: { token?: string | null; raw?: string } = {},
+) => {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== null) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return new Request('http://localhost/api/blog', {
+    method: 'POST',
+    headers,
+    body: raw ?? JSON.stringify(body),
+  });
+};
+
+const callPost = async (body: unknown, opts?: Parameters<typeof buildRequest>[1]) => {
+  const res = await POST(buildRequest(body, opts));
+  const json = await res.json();
+  return { status: res.status, body: json };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.BLOG_API_TOKEN = TOKEN;
+  vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(samplePosts()));
+  vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+  vi.mocked(fs.rename).mockResolvedValue(undefined);
+});
+
+describe('POST /api/blog — authentication', () => {
+  it('rejects requests without an Authorization header', async () => {
+    const { status, body } = await callPost({ action: 'list' }, { token: null });
+    expect(status).toBe(401);
+    expect(body).toEqual({ ok: false, error: 'unauthorized' });
+  });
+
+  it('rejects requests with the wrong token', async () => {
+    const { status, body } = await callPost({ action: 'list' }, { token: 'wrong' });
+    expect(status).toBe(401);
+    expect(body.error).toBe('unauthorized');
+  });
+
+  it('rejects requests when BLOG_API_TOKEN is unset on the server', async () => {
+    delete process.env.BLOG_API_TOKEN;
+    const { status } = await callPost({ action: 'list' });
+    expect(status).toBe(401);
+  });
+
+  it('accepts the correct token', async () => {
+    const { status } = await callPost({ action: 'list' });
+    expect(status).toBe(200);
+  });
+});
+
+describe('POST /api/blog — request validation', () => {
+  it('returns invalid_json when the body is not JSON', async () => {
+    const { status, body } = await callPost(undefined, { raw: 'not-json' });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_json');
+  });
+
+  it('returns invalid_request for an unknown action', async () => {
+    const { status, body } = await callPost({ action: 'delete', slug: 'foo' });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_request');
+    expect(body.details.fieldErrors.action).toBeDefined();
+  });
+
+  it('rejects a create payload that is missing required fields', async () => {
+    const { status, body } = await callPost({ action: 'create', post: { title: 'oi' } });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_request');
+    // Three issues: title too short, excerpt missing, body missing.
+    expect(body.details.fieldErrors.post).toHaveLength(3);
+    expect(body.details.fieldErrors.post).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('expected array'),
+      ]),
+    );
+  });
+});
+
+describe('POST /api/blog — list', () => {
+  it('returns posts sorted newest first', async () => {
+    const { status, body } = await callPost({ action: 'list' });
+    expect(status).toBe(200);
+    expect(body.data.total).toBe(3);
+    expect(body.data.posts.map((p: { slug: string }) => p.slug)).toEqual([
+      'post-a',
+      'post-b',
+      'post-c',
+    ]);
+  });
+
+  it('strips body blocks from the summary payload', async () => {
+    const { body } = await callPost({ action: 'list' });
+    expect(body.data.posts[0]).not.toHaveProperty('body');
+  });
+
+  it('filters by exact category label', async () => {
+    const { body } = await callPost({ action: 'list', category: 'Design' });
+    expect(body.data.posts).toHaveLength(1);
+    expect(body.data.posts[0].slug).toBe('post-b');
+  });
+
+  it('filters by categorySlug (diacritic-insensitive)', async () => {
+    const { body } = await callPost({
+      action: 'list',
+      categorySlug: 'inteligencia-artificial',
+    });
+    expect(body.data.posts).toHaveLength(1);
+    expect(body.data.posts[0].slug).toBe('post-c');
+  });
+
+  it('paginates with limit and offset', async () => {
+    const { body } = await callPost({ action: 'list', limit: 1, offset: 1 });
+    expect(body.data.total).toBe(3);
+    expect(body.data.count).toBe(1);
+    expect(body.data.posts[0].slug).toBe('post-b');
+  });
+});
+
+describe('POST /api/blog — read', () => {
+  it('returns the full post for an existing slug', async () => {
+    const { status, body } = await callPost({ action: 'read', slug: 'post-a' });
+    expect(status).toBe(200);
+    expect(body.data.post.slug).toBe('post-a');
+    expect(body.data.post.body).toBeDefined();
+  });
+
+  it('returns 404 for an unknown slug', async () => {
+    const { status, body } = await callPost({ action: 'read', slug: 'nope' });
+    expect(status).toBe(404);
+    expect(body.error).toBe('not_found');
+    expect(body.details).toEqual({ slug: 'nope' });
+  });
+});
+
+describe('POST /api/blog — create', () => {
+  it('auto-generates slug from title and computes reading time', async () => {
+    const longText = 'palavra '.repeat(400).trim();
+    const { status, body } = await callPost({
+      action: 'create',
+      post: {
+        title: 'Novo post sobre IA',
+        excerpt: 'Resumo suficientemente longo para passar na validação.',
+        body: [{ type: 'paragraph', text: longText }],
+      },
+    });
+    expect(status).toBe(201);
+    expect(body.data.post.slug).toBe('novo-post-sobre-ia');
+    // 400 words / 200 wpm → 2 min
+    expect(body.data.post.readingTimeMinutes).toBe(2);
+    expect(body.data.post.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('writes the new post at the head of the array', async () => {
+    await callPost({
+      action: 'create',
+      post: {
+        title: 'Novo Post',
+        excerpt: 'Excerpt long enough for the validator.',
+        body: [{ type: 'paragraph', text: 'hi' }],
+      },
+    });
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(fs.rename).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(vi.mocked(fs.writeFile).mock.calls[0]![1] as string);
+    expect(written[0].slug).toBe('novo-post');
+    expect(written).toHaveLength(4);
+  });
+
+  it('rejects a duplicate slug with 409', async () => {
+    const { status, body } = await callPost({
+      action: 'create',
+      post: {
+        slug: 'post-a',
+        title: 'Already exists',
+        excerpt: 'Excerpt long enough for the validator.',
+        body: [{ type: 'paragraph', text: 'x' }],
+      },
+    });
+    expect(status).toBe(409);
+    expect(body.error).toBe('slug_conflict');
+    expect(body.details).toEqual({ slug: 'post-a' });
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid_slug when title slugifies to empty', async () => {
+    const { status, body } = await callPost({
+      action: 'create',
+      post: {
+        title: '!!!',
+        excerpt: 'Excerpt long enough for the validator.',
+        body: [{ type: 'paragraph', text: 'x' }],
+      },
+    });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_slug');
+  });
+});
+
+describe('POST /api/blog — update', () => {
+  it('merges patch, preserves slug, bumps updatedAt', async () => {
+    const { status, body } = await callPost({
+      action: 'update',
+      slug: 'post-a',
+      patch: { category: 'Inteligência Artificial' },
+    });
+    expect(status).toBe(200);
+    expect(body.data.post.slug).toBe('post-a');
+    expect(body.data.post.category).toBe('Inteligência Artificial');
+    expect(body.data.post.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('recomputes reading time when body changes', async () => {
+    const newBody = [{ type: 'paragraph' as const, text: 'word '.repeat(600).trim() }];
+    const { body } = await callPost({
+      action: 'update',
+      slug: 'post-a',
+      patch: { body: newBody },
+    });
+    // 600 words / 200 wpm → 3 min
+    expect(body.data.post.readingTimeMinutes).toBe(3);
+  });
+
+  it('returns 404 for an unknown slug', async () => {
+    const { status, body } = await callPost({
+      action: 'update',
+      slug: 'nope',
+      patch: { category: 'Produto' },
+    });
+    expect(status).toBe(404);
+    expect(body.error).toBe('not_found');
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects slug-in-patch', async () => {
+    const { status, body } = await callPost({
+      action: 'update',
+      slug: 'post-a',
+      patch: { slug: 'renamed' },
+    });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_request');
+    expect(body.details.fieldErrors.patch).toBeDefined();
+  });
+});
+
+describe('POST /api/blog — storage errors', () => {
+  it('returns 500 storage_read_failed when readFile throws', async () => {
+    vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('disk gone'));
+    const { status, body } = await callPost({ action: 'list' });
+    expect(status).toBe(500);
+    expect(body.error).toBe('storage_read_failed');
+  });
+
+  it('returns 500 storage_write_failed when create cannot persist', async () => {
+    vi.mocked(fs.writeFile).mockRejectedValueOnce(new Error('read-only fs'));
+    const { status, body } = await callPost({
+      action: 'create',
+      post: {
+        title: 'Novo Post',
+        excerpt: 'Excerpt long enough for the validator.',
+        body: [{ type: 'paragraph', text: 'hi' }],
+      },
+    });
+    expect(status).toBe(500);
+    expect(body.error).toBe('storage_write_failed');
+  });
+});

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -1,0 +1,311 @@
+import { Buffer } from 'node:buffer';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { slugifyCategory } from '@/components/blog/categories';
+import type { BlogBodyBlock, BlogPost } from '@/types/blog';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const BLOG_PATH = path.resolve(process.cwd(), 'src/data/blog.json');
+
+const dateOrIso = z
+  .string()
+  .regex(
+    /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/,
+    'must be YYYY-MM-DD or ISO 8601 datetime',
+  );
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .max(120)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'must be lowercase letters, digits and hyphens');
+
+const imageSrcSchema = z
+  .string()
+  .min(1)
+  .refine(s => s.startsWith('http://') || s.startsWith('https://') || s.startsWith('/'), {
+    message: 'must be an absolute URL or a path starting with /',
+  });
+
+const bodyBlockSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('paragraph'), text: z.string().min(1) }),
+  z.object({
+    type: z.literal('heading'),
+    level: z.union([z.literal(2), z.literal(3)]),
+    text: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal('list'),
+    ordered: z.boolean().optional(),
+    items: z.array(z.string().min(1)).min(1),
+  }),
+  z.object({
+    type: z.literal('quote'),
+    text: z.string().min(1),
+    cite: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('image'),
+    src: imageSrcSchema,
+    alt: z.string().min(1),
+    caption: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal('code'),
+    language: z.string().optional(),
+    code: z.string().min(1),
+  }),
+]);
+
+const authorSchema = z.object({
+  name: z.string().min(1),
+  avatar: imageSrcSchema.optional(),
+  role: z.string().optional(),
+});
+
+const postCreateSchema = z.object({
+  slug: slugSchema.optional(),
+  title: z.string().min(3).max(200),
+  excerpt: z.string().min(10).max(500),
+  coverImage: imageSrcSchema.optional(),
+  coverAlt: z.string().optional(),
+  publishedAt: dateOrIso.optional(),
+  updatedAt: dateOrIso.optional(),
+  readingTimeMinutes: z.number().int().positive().max(120).optional(),
+  category: z.string().min(1).max(60).optional(),
+  tags: z.array(z.string().min(1).max(40)).max(20).optional(),
+  author: authorSchema.optional(),
+  body: z.array(bodyBlockSchema).min(1),
+});
+
+const postPatchSchema = postCreateSchema.partial().extend({
+  slug: z.never().optional(),
+});
+
+const requestSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('list'),
+    category: z.string().optional(),
+    categorySlug: z.string().optional(),
+    limit: z.number().int().positive().max(100).optional(),
+    offset: z.number().int().nonnegative().optional(),
+  }),
+  z.object({ action: z.literal('read'), slug: slugSchema }),
+  z.object({ action: z.literal('create'), post: postCreateSchema }),
+  z.object({ action: z.literal('update'), slug: slugSchema, patch: postPatchSchema }),
+]);
+
+const slugifyTitle = (title: string) =>
+  title
+    .normalize('NFD')
+    .replace(/\p{Mn}/gu, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 120);
+
+const extractText = (block: BlogBodyBlock): string => {
+  switch (block.type) {
+    case 'paragraph':
+    case 'heading':
+    case 'quote':
+      return block.text;
+    case 'list':
+      return block.items.join(' ');
+    case 'code':
+      return block.code;
+    case 'image':
+      return `${block.alt} ${block.caption ?? ''}`;
+    default:
+      return '';
+  }
+};
+
+const estimateReadingTime = (blocks: BlogBodyBlock[]) => {
+  const text = blocks.map(extractText).join(' ');
+  const words = text.split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / 200));
+};
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const summarize = (post: BlogPost) => ({
+  slug: post.slug,
+  title: post.title,
+  excerpt: post.excerpt,
+  category: post.category,
+  publishedAt: post.publishedAt,
+  updatedAt: post.updatedAt,
+  readingTimeMinutes: post.readingTimeMinutes,
+  coverImage: post.coverImage,
+});
+
+const isAuthorized = (req: Request) => {
+  const expected = process.env.BLOG_API_TOKEN;
+  if (!expected) {
+    return false;
+  }
+  const header = req.headers.get('authorization') ?? '';
+  // Anchored single-space separator avoids super-linear backtracking on \s+(.+).
+  const match = /^Bearer (\S.*)$/i.exec(header);
+  if (!match || !match[1]) {
+    return false;
+  }
+  const provided = match[1].trim();
+  const expectedBuf = Buffer.from(expected);
+  const providedBuf = Buffer.from(provided);
+  if (expectedBuf.length !== providedBuf.length) {
+    return false;
+  }
+  try {
+    return crypto.timingSafeEqual(expectedBuf, providedBuf);
+  } catch {
+    return false;
+  }
+};
+
+const readPosts = async (): Promise<BlogPost[]> => {
+  const raw = await fs.readFile(BLOG_PATH, 'utf8');
+  return JSON.parse(raw) as BlogPost[];
+};
+
+const writePosts = async (posts: BlogPost[]) => {
+  const tmp = `${BLOG_PATH}.tmp`;
+  await fs.writeFile(tmp, `${JSON.stringify(posts, null, 2)}\n`, 'utf8');
+  await fs.rename(tmp, BLOG_PATH);
+};
+
+const errorResponse = (status: number, error: string, details?: unknown) =>
+  NextResponse.json({ ok: false, error, ...(details === undefined ? {} : { details }) }, { status });
+
+export async function POST(req: Request) {
+  if (!isAuthorized(req)) {
+    return errorResponse(401, 'unauthorized');
+  }
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return errorResponse(400, 'invalid_json');
+  }
+
+  const parsed = requestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return errorResponse(400, 'invalid_request', parsed.error.flatten());
+  }
+
+  const command = parsed.data;
+
+  let posts: BlogPost[];
+  try {
+    posts = await readPosts();
+  } catch {
+    return errorResponse(500, 'storage_read_failed');
+  }
+
+  switch (command.action) {
+    case 'list': {
+      const filtered = posts.filter((post) => {
+        if (command.categorySlug) {
+          return post.category ? slugifyCategory(post.category) === command.categorySlug : false;
+        }
+        if (command.category) {
+          return post.category === command.category;
+        }
+        return true;
+      });
+      const sorted = [...filtered].sort(
+        (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+      );
+      const offset = command.offset ?? 0;
+      const limit = command.limit ?? sorted.length;
+      const items = sorted.slice(offset, offset + limit).map(summarize);
+      return NextResponse.json({
+        ok: true,
+        data: {
+          total: filtered.length,
+          count: items.length,
+          offset,
+          limit,
+          posts: items,
+        },
+      });
+    }
+
+    case 'read': {
+      const post = posts.find(p => p.slug === command.slug);
+      if (!post) {
+        return errorResponse(404, 'not_found', { slug: command.slug });
+      }
+      return NextResponse.json({ ok: true, data: { post } });
+    }
+
+    case 'create': {
+      const input = command.post;
+      const slug = input.slug ?? slugifyTitle(input.title);
+      if (!slug) {
+        return errorResponse(400, 'invalid_slug', { reason: 'title produced empty slug' });
+      }
+      if (posts.some(p => p.slug === slug)) {
+        return errorResponse(409, 'slug_conflict', { slug });
+      }
+      const newPost: BlogPost = {
+        slug,
+        title: input.title,
+        excerpt: input.excerpt,
+        coverImage: input.coverImage,
+        coverAlt: input.coverAlt,
+        publishedAt: input.publishedAt ?? today(),
+        updatedAt: input.updatedAt,
+        readingTimeMinutes: input.readingTimeMinutes ?? estimateReadingTime(input.body),
+        category: input.category,
+        tags: input.tags,
+        author: input.author,
+        body: input.body,
+      };
+      const next = [newPost, ...posts];
+      try {
+        await writePosts(next);
+      } catch {
+        return errorResponse(500, 'storage_write_failed');
+      }
+      return NextResponse.json({ ok: true, data: { post: newPost } }, { status: 201 });
+    }
+
+    case 'update': {
+      const index = posts.findIndex(p => p.slug === command.slug);
+      if (index === -1) {
+        return errorResponse(404, 'not_found', { slug: command.slug });
+      }
+      const current = posts[index]!;
+      const patch = command.patch;
+      const merged: BlogPost = {
+        ...current,
+        ...patch,
+        slug: current.slug,
+        updatedAt: today(),
+        body: patch.body ?? current.body,
+      };
+      if (patch.body) {
+        merged.readingTimeMinutes = patch.readingTimeMinutes ?? estimateReadingTime(patch.body);
+      }
+      const next = [...posts];
+      next[index] = merged;
+      try {
+        await writePosts(next);
+      } catch {
+        return errorResponse(500, 'storage_write_failed');
+      }
+      return NextResponse.json({ ok: true, data: { post: merged } });
+    }
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,9 @@
 import type { MetadataRoute } from 'next';
 
+import { getAllCategorySlugs } from '@/components/blog/categories';
+import blogData from '@/data/blog.json';
 import portfolioData from '@/data/portfolio.json';
+import type { BlogPost } from '@/types/blog';
 import type { Project } from '@/types/portfolio';
 import { AppConfig } from '@/utils/AppConfig';
 import { localizedUrl } from '@/utils/seo';
@@ -15,6 +18,7 @@ const STATIC_ROUTES: StaticRoute[] = [
   { path: '/', changeFrequency: 'weekly', priority: 1 },
   { path: '/sobre-nos', changeFrequency: 'monthly', priority: 0.9 },
   { path: '/portfolio', changeFrequency: 'weekly', priority: 0.9 },
+  { path: '/blog', changeFrequency: 'daily', priority: 0.8 },
 ];
 
 const buildLanguageAlternates = (path: string) => {
@@ -66,6 +70,36 @@ export default function sitemap(): MetadataRoute.Sitemap {
         changeFrequency: 'monthly',
         priority: locale === AppConfig.defaultLocale ? 0.7 : 0.6,
         alternates: { languages: buildLanguageAlternates(portfolioPath) },
+      });
+    }
+  }
+
+  // Blog article pages, one row per locale, lastModified from the post itself.
+  const blogPosts = blogData as BlogPost[];
+  for (const post of blogPosts) {
+    const blogPath = `/blog/${post.slug}`;
+    const lastModified = new Date(post.updatedAt ?? post.publishedAt);
+    for (const locale of AppConfig.locales) {
+      entries.push({
+        url: localizedUrl(locale, blogPath),
+        lastModified,
+        changeFrequency: 'monthly',
+        priority: locale === AppConfig.defaultLocale ? 0.7 : 0.6,
+        alternates: { languages: buildLanguageAlternates(blogPath) },
+      });
+    }
+  }
+
+  // Blog category index pages, one row per locale per category.
+  for (const categorySlug of getAllCategorySlugs(blogPosts)) {
+    const categoryPath = `/blog/category/${categorySlug}`;
+    for (const locale of AppConfig.locales) {
+      entries.push({
+        url: localizedUrl(locale, categoryPath),
+        lastModified: now,
+        changeFrequency: 'weekly',
+        priority: locale === AppConfig.defaultLocale ? 0.6 : 0.5,
+        alternates: { languages: buildLanguageAlternates(categoryPath) },
       });
     }
   }

--- a/src/components/LocaleSwitcher/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher/LocaleSwitcher.tsx
@@ -17,15 +17,36 @@ const LOCALE_META: Record<
   'en': { label: 'EN', ariaLabel: 'Switch to English', Flag: UsFlag },
 };
 
+type LocaleSwitcherTheme = 'light' | 'dark';
+
 type LocaleSwitcherProps = {
   className?: string;
+  theme?: LocaleSwitcherTheme;
 };
 
-const LocaleSwitcher = ({ className }: LocaleSwitcherProps) => {
+const THEME_STYLES: Record<LocaleSwitcherTheme, {
+  container: string;
+  active: string;
+  inactive: string;
+}> = {
+  dark: {
+    container: 'border-white/10 bg-white/[0.04]',
+    active: 'bg-white/15 text-white',
+    inactive: 'text-white/60 hover:bg-white/[0.06] hover:text-white',
+  },
+  light: {
+    container: 'border-black/[0.08] bg-black/[0.03]',
+    active: 'bg-black/[0.08] text-neutral-900',
+    inactive: 'text-neutral-500 hover:bg-black/[0.04] hover:text-neutral-900',
+  },
+};
+
+const LocaleSwitcher = ({ className, theme = 'dark' }: LocaleSwitcherProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const activeLocale = useLocale();
   const [isPending, startTransition] = useTransition();
+  const styles = THEME_STYLES[theme];
 
   const handleSelect = (nextLocale: (typeof AppConfig.locales)[number]) => {
     if (nextLocale === activeLocale || isPending) {
@@ -39,7 +60,8 @@ const LocaleSwitcher = ({ className }: LocaleSwitcherProps) => {
   return (
     <div
       className={classNames(
-        'flex items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] p-0.5',
+        'flex items-center gap-1 rounded-full border p-0.5',
+        styles.container,
         className,
       )}
       role="group"
@@ -62,9 +84,7 @@ const LocaleSwitcher = ({ className }: LocaleSwitcherProps) => {
             onClick={() => handleSelect(locale)}
             className={classNames(
               'flex items-center gap-1.5 rounded-full px-2 py-1 text-xs font-semibold transition-colors',
-              isActive
-                ? 'bg-white/15 text-white'
-                : 'text-white/60 hover:bg-white/[0.06] hover:text-white',
+              isActive ? styles.active : styles.inactive,
             )}
           >
             <Flag className="size-4" />

--- a/src/components/blog/BlogArticleBody.tsx
+++ b/src/components/blog/BlogArticleBody.tsx
@@ -1,0 +1,96 @@
+import Image from 'next/image';
+
+import type { BlogBodyBlock } from '@/types/blog';
+
+type BlogArticleBodyProps = {
+  blocks: BlogBodyBlock[];
+};
+
+const BlogArticleBody = ({ blocks }: BlogArticleBodyProps) => {
+  return (
+    <div className="space-y-6 text-[17px] leading-[1.75] text-neutral-700">
+      {blocks.map((block, index) => {
+        switch (block.type) {
+          case 'paragraph':
+            return <p key={index}>{block.text}</p>;
+          case 'heading':
+            return block.level === 3
+              ? (
+                  <h3 key={index} className="mt-10 text-xl font-semibold text-neutral-900">
+                    {block.text}
+                  </h3>
+                )
+              : (
+                  <h2 key={index} className="mt-12 text-2xl font-semibold text-neutral-900 md:text-[1.75rem]">
+                    {block.text}
+                  </h2>
+                );
+          case 'list': {
+            const Tag = block.ordered ? 'ol' : 'ul';
+            return (
+              <Tag
+                key={index}
+                className={`${block.ordered ? 'list-decimal' : 'list-disc'} space-y-2 pl-6 marker:text-primary`}
+              >
+                {block.items.map((item, itemIndex) => (
+                  <li key={itemIndex}>{item}</li>
+                ))}
+              </Tag>
+            );
+          }
+          case 'quote':
+            return (
+              <blockquote
+                key={index}
+                className="my-10 border-l-2 border-primary py-2 pl-6 text-xl font-medium leading-snug text-neutral-900"
+              >
+                <p>
+                  &ldquo;
+                  {block.text}
+                  &rdquo;
+                </p>
+                {block.cite && (
+                  <cite className="mt-3 block text-sm not-italic text-neutral-500">
+                    —
+                    {' '}
+                    {block.cite}
+                  </cite>
+                )}
+              </blockquote>
+            );
+          case 'image':
+            return (
+              <figure key={index} className="my-10 overflow-hidden rounded-xl border border-neutral-200">
+                <Image
+                  src={block.src}
+                  alt={block.alt}
+                  width={1600}
+                  height={900}
+                  sizes="(max-width: 768px) 100vw, 768px"
+                  className="h-auto w-full"
+                />
+                {block.caption && (
+                  <figcaption className="bg-neutral-50 px-4 py-3 text-center text-sm text-neutral-500">
+                    {block.caption}
+                  </figcaption>
+                )}
+              </figure>
+            );
+          case 'code':
+            return (
+              <pre
+                key={index}
+                className="overflow-x-auto rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm leading-relaxed text-neutral-800"
+              >
+                <code>{block.code}</code>
+              </pre>
+            );
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+};
+
+export default BlogArticleBody;

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Image from 'next/image';
+
+import { Link } from '@/libs/i18nNavigation';
+
+import { formatShortDate } from './formatDate';
+
+export type BlogCardItem = {
+  slug: string;
+  title: string;
+  excerpt: string;
+  coverImage?: string;
+  coverAlt?: string;
+  category?: string;
+  publishedAt: string;
+  readingTimeMinutes?: number;
+};
+
+type BlogCardProps = {
+  item: BlogCardItem;
+  locale: string;
+};
+
+const BlogCard = ({ item, locale }: BlogCardProps) => {
+  const dateLabel = formatShortDate(item.publishedAt, locale);
+
+  return (
+    <Link
+      href={`/blog/${item.slug}`}
+      className="group flex h-full flex-col gap-5 rounded-2xl border border-neutral-200 bg-white p-6 transition-colors hover:border-neutral-300"
+    >
+      <div className="flex items-center gap-2 text-[11px] font-semibold tracking-[0.12em] text-neutral-500">
+        <span>{dateLabel}</span>
+        {item.category && (
+          <>
+            <span aria-hidden className="text-neutral-300">·</span>
+            <span className="uppercase text-primary">{item.category}</span>
+          </>
+        )}
+      </div>
+
+      <div className="flex flex-1 items-start gap-4">
+        <h3 className="flex-1 text-base font-semibold leading-snug text-neutral-900 transition-colors group-hover:text-primary">
+          {item.title}
+        </h3>
+        {item.coverImage && (
+          <div className="relative size-20 shrink-0 overflow-hidden rounded-lg bg-neutral-100">
+            <Image
+              src={item.coverImage}
+              alt={item.coverAlt ?? item.title}
+              fill
+              sizes="80px"
+              className="object-cover transition-transform duration-500 group-hover:scale-[1.05]"
+            />
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+};
+
+export default BlogCard;

--- a/src/components/blog/BlogCategoryTabs.tsx
+++ b/src/components/blog/BlogCategoryTabs.tsx
@@ -1,0 +1,70 @@
+import classNames from 'classnames';
+
+import { Link } from '@/libs/i18nNavigation';
+
+import type { BlogCategoryRef } from './categories';
+
+type BlogCategoryTabsProps = {
+  categories: BlogCategoryRef[];
+  activeSlug: string;
+  allLabel: string;
+  allSlug?: string;
+};
+
+const ALL_SLUG = '__all__';
+
+const BlogCategoryTabs = ({
+  categories,
+  activeSlug,
+  allLabel,
+  allSlug = ALL_SLUG,
+}: BlogCategoryTabsProps) => {
+  const items: { slug: string; label: string; href: string }[] = [
+    { slug: allSlug, label: allLabel, href: '/blog' },
+    ...categories.map(category => ({
+      slug: category.slug,
+      label: category.label,
+      href: `/blog/category/${category.slug}`,
+    })),
+  ];
+
+  return (
+    <nav
+      aria-label="Blog categories"
+      className="-mx-4 border-b border-neutral-200 px-4 sm:mx-0 sm:px-0"
+    >
+      <ul
+        className="flex h-12 min-w-max items-stretch gap-1 overflow-x-auto overflow-y-hidden sm:gap-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {items.map((item) => {
+          const isActive = item.slug === activeSlug;
+          return (
+            <li key={item.slug} className="flex">
+              <Link
+                href={item.href}
+                aria-current={isActive ? 'page' : undefined}
+                className={classNames(
+                  'relative inline-flex items-center whitespace-nowrap px-3 text-sm transition-colors',
+                  isActive
+                    ? 'font-semibold text-neutral-900'
+                    : 'font-medium text-neutral-500 hover:text-neutral-900',
+                )}
+              >
+                {item.label}
+                {isActive && (
+                  <span
+                    aria-hidden
+                    className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-primary"
+                  />
+                )}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+};
+
+export { ALL_SLUG };
+export default BlogCategoryTabs;

--- a/src/components/blog/BlogFeaturedCard.tsx
+++ b/src/components/blog/BlogFeaturedCard.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Image from 'next/image';
+
+import { Link } from '@/libs/i18nNavigation';
+
+import type { BlogCardItem } from './BlogCard';
+import { formatShortDate } from './formatDate';
+
+type BlogFeaturedCardProps = {
+  item: BlogCardItem;
+  locale: string;
+  readArticleLabel: string;
+};
+
+const BlogFeaturedCard = ({ item, locale, readArticleLabel }: BlogFeaturedCardProps) => {
+  const dateLabel = formatShortDate(item.publishedAt, locale);
+
+  return (
+    <Link
+      href={`/blog/${item.slug}`}
+      className="group grid grid-cols-1 overflow-hidden rounded-2xl border border-neutral-200 bg-white transition-colors hover:border-neutral-300 lg:grid-cols-[1.6fr_1fr]"
+    >
+      {item.coverImage
+        ? (
+            <div className="relative aspect-[16/10] overflow-hidden bg-gradient-to-br from-neutral-50 to-neutral-100 lg:aspect-auto">
+              <Image
+                src={item.coverImage}
+                alt={item.coverAlt ?? item.title}
+                fill
+                sizes="(max-width: 1024px) 100vw, 60vw"
+                className="object-cover transition-transform duration-500 group-hover:scale-[1.02]"
+                priority
+              />
+            </div>
+          )
+        : (
+            <div className="aspect-[16/10] bg-gradient-to-br from-neutral-100 to-neutral-50 lg:aspect-auto" />
+          )}
+
+      <div className="flex flex-col justify-center gap-5 p-8 md:p-10 lg:p-12">
+        <div className="flex items-center gap-2 text-xs font-semibold tracking-[0.12em] text-neutral-500">
+          <span>{dateLabel}</span>
+          {item.category && (
+            <>
+              <span aria-hidden className="text-neutral-300">/</span>
+              <span className="uppercase text-primary">{item.category}</span>
+            </>
+          )}
+        </div>
+
+        <h2 className="text-3xl font-bold leading-[1.15] tracking-tight text-neutral-900 transition-colors group-hover:text-primary md:text-4xl">
+          {item.title}
+        </h2>
+
+        <p className="line-clamp-3 text-base leading-relaxed text-neutral-600">
+          {item.excerpt}
+        </p>
+
+        <span className="mt-2 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-neutral-900">
+          {readArticleLabel}
+          <span className="inline-flex size-7 items-center justify-center rounded-full bg-neutral-900 text-white transition-transform group-hover:translate-x-1">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <line x1="5" y1="12" x2="19" y2="12" />
+              <polyline points="12 5 19 12 12 19" />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </Link>
+  );
+};
+
+export default BlogFeaturedCard;

--- a/src/components/blog/BlogFooter.tsx
+++ b/src/components/blog/BlogFooter.tsx
@@ -1,0 +1,48 @@
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+
+import { Link } from '@/libs/i18nNavigation';
+
+const BlogFooter = () => {
+  const t = useTranslations('Footer');
+  const tNav = useTranslations('Navbar');
+  const tBlog = useTranslations('BlogPage');
+
+  return (
+    <footer className="border-t border-neutral-200 bg-white py-12">
+      <div className="mx-auto flex max-w-5xl flex-col items-start justify-between gap-6 px-4 sm:flex-row sm:items-center sm:px-6">
+        <Link href="/" className="flex items-center gap-2.5">
+          <Image src="/assets/images/logo/logo_symbol_black.svg" alt="Agility" width={24} height={24} />
+          <Image src="/assets/images/logo/logo_name_black.svg" alt="Agility" width={76} height={20} />
+        </Link>
+
+        <nav className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-neutral-500">
+          <Link href="/blog" className="transition-colors hover:text-neutral-900">
+            {tBlog('badge')}
+          </Link>
+          <Link href="/portfolio" className="transition-colors hover:text-neutral-900">
+            {tNav('portfolio')}
+          </Link>
+          <Link href="/sobre-nos" className="transition-colors hover:text-neutral-900">
+            {tNav('about')}
+          </Link>
+          <a href="mailto:hi@agilitycreative.com" className="transition-colors hover:text-neutral-900">
+            hi@agilitycreative.com
+          </a>
+        </nav>
+
+        <p className="text-xs text-neutral-400">
+          ©
+          {' '}
+          {new Date().getFullYear()}
+          {' '}
+          Agility Creative.
+          {' '}
+          {t('copyright')}
+        </p>
+      </div>
+    </footer>
+  );
+};
+
+export default BlogFooter;

--- a/src/components/blog/BlogHeader.tsx
+++ b/src/components/blog/BlogHeader.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { motion, useMotionValueEvent, useScroll } from 'motion/react';
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+import LocaleSwitcher from '@/components/LocaleSwitcher';
+import { Link } from '@/libs/i18nNavigation';
+
+const HIDE_AFTER = 80;
+const SHADOW_AFTER = 8;
+
+const BlogHeader = () => {
+  const t = useTranslations('Navbar');
+  const tBlog = useTranslations('BlogPage');
+  const [hidden, setHidden] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+  const { scrollY } = useScroll();
+
+  useMotionValueEvent(scrollY, 'change', (latest) => {
+    const previous = scrollY.getPrevious() ?? 0;
+    const goingDown = latest > previous;
+    setHidden(latest > HIDE_AFTER && goingDown);
+    setScrolled(latest > SHADOW_AFTER);
+  });
+
+  return (
+    <motion.header
+      className={`sticky top-0 z-50 border-b transition-shadow duration-300 ${
+        scrolled ? 'border-neutral-200 bg-white/95 shadow-[0_1px_0_rgba(0,0,0,0.02)] backdrop-blur' : 'border-transparent bg-white'
+      }`}
+      initial={{ y: -80, opacity: 0 }}
+      animate={{ y: hidden ? -80 : 0, opacity: 1 }}
+      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+    >
+      <div className="mx-auto flex h-16 max-w-5xl items-center justify-between gap-6 px-4 sm:px-6">
+        <Link href="/" className="flex items-center gap-2.5">
+          <Image src="/assets/images/logo/logo_symbol_black.svg" alt="Agility" width={26} height={26} />
+          <Image src="/assets/images/logo/logo_name_black.svg" alt="Agility" width={82} height={20} className="hidden sm:block" />
+        </Link>
+
+        <nav className="flex items-center gap-1 sm:gap-2">
+          <Link
+            href="/blog"
+            className="rounded-full px-3 py-1.5 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900"
+          >
+            {tBlog('badge')}
+          </Link>
+          <Link
+            href="/"
+            className="hidden rounded-full px-3 py-1.5 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900 sm:inline-block"
+          >
+            {t('home')}
+          </Link>
+          <LocaleSwitcher theme="light" className="ml-1" />
+          <Link
+            href="/#Contato"
+            className="ml-1 hidden rounded-full bg-neutral-900 px-4 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-neutral-700 sm:inline-block"
+          >
+            {t('cta')}
+          </Link>
+        </nav>
+      </div>
+    </motion.header>
+  );
+};
+
+export default BlogHeader;

--- a/src/components/blog/BlogHero.tsx
+++ b/src/components/blog/BlogHero.tsx
@@ -1,0 +1,88 @@
+import { Link } from '@/libs/i18nNavigation';
+
+type Breadcrumb = {
+  label: string;
+  href?: string;
+};
+
+type BlogHeroProps = {
+  eyebrow?: string;
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  meta?: React.ReactNode;
+  breadcrumbs?: Breadcrumb[];
+  align?: 'left' | 'center';
+  size?: 'sm' | 'md' | 'lg';
+};
+
+const SIZE_TO_TITLE = {
+  sm: 'text-2xl md:text-3xl',
+  md: 'text-3xl md:text-4xl lg:text-[2.75rem]',
+  lg: 'text-4xl md:text-5xl lg:text-[3.25rem]',
+} as const;
+
+const BlogHero = ({
+  eyebrow,
+  title,
+  subtitle,
+  meta,
+  breadcrumbs,
+  align = 'left',
+  size = 'lg',
+}: BlogHeroProps) => {
+  const isCenter = align === 'center';
+
+  return (
+    <section className="border-b border-neutral-200/70 bg-white">
+      <div className={`mx-auto max-w-6xl px-4 pb-10 pt-14 sm:px-6 md:pb-14 md:pt-20 ${isCenter ? 'text-center' : 'text-left'}`}>
+        {breadcrumbs && breadcrumbs.length > 0 && (
+          <nav
+            aria-label="Breadcrumb"
+            className={`mb-6 flex flex-wrap items-center gap-1.5 text-xs text-neutral-500 ${isCenter ? 'justify-center' : ''}`}
+          >
+            {breadcrumbs.map((crumb, index) => (
+              <div key={index} className="flex items-center gap-1.5">
+                {crumb.href
+                  ? (
+                      <Link href={crumb.href} className="transition-colors hover:text-neutral-900">
+                        {crumb.label}
+                      </Link>
+                    )
+                  : (
+                      <span className="text-neutral-700">{crumb.label}</span>
+                    )}
+                {index < breadcrumbs.length - 1 && <span className="text-neutral-300">/</span>}
+              </div>
+            ))}
+          </nav>
+        )}
+
+        <div className={isCenter ? 'mx-auto max-w-3xl' : 'max-w-3xl'}>
+          {eyebrow && (
+            <p className="mb-4 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+              {eyebrow}
+            </p>
+          )}
+
+          <h1 className={`font-bold leading-[1.1] tracking-tight text-neutral-900 ${SIZE_TO_TITLE[size]}`}>
+            {title}
+          </h1>
+
+          {subtitle && (
+            <p className="mt-5 text-base leading-relaxed text-neutral-600 md:mt-6 md:text-lg">
+              {subtitle}
+            </p>
+          )}
+
+          {meta && (
+            <div className={`mt-7 flex flex-wrap items-center gap-3 text-sm text-neutral-500 ${isCenter ? 'justify-center' : ''}`}>
+              {meta}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BlogHero;

--- a/src/components/blog/BlogIndex.tsx
+++ b/src/components/blog/BlogIndex.tsx
@@ -1,0 +1,63 @@
+import type { BlogCardItem } from './BlogCard';
+import BlogCard from './BlogCard';
+import BlogCategoryTabs, { ALL_SLUG } from './BlogCategoryTabs';
+import BlogFeaturedCard from './BlogFeaturedCard';
+import type { BlogCategoryRef } from './categories';
+
+type BlogIndexProps = {
+  items: BlogCardItem[];
+  categories: BlogCategoryRef[];
+  activeSlug?: string;
+  locale: string;
+  allLabel: string;
+  readArticleLabel: string;
+  emptyLabel: string;
+};
+
+const BlogIndex = ({
+  items,
+  categories,
+  activeSlug = ALL_SLUG,
+  locale,
+  allLabel,
+  readArticleLabel,
+  emptyLabel,
+}: BlogIndexProps) => {
+  const [featured, ...rest] = items;
+
+  return (
+    <section className="mx-auto max-w-6xl px-4 pb-24 pt-4 sm:px-6 md:pb-32 md:pt-6">
+      <BlogCategoryTabs
+        categories={categories}
+        activeSlug={activeSlug}
+        allLabel={allLabel}
+      />
+
+      {!featured && (
+        <p className="mt-12 rounded-xl border border-dashed border-neutral-200 bg-neutral-50 px-6 py-16 text-center text-sm text-neutral-500">
+          {emptyLabel}
+        </p>
+      )}
+
+      {featured && (
+        <div className="mt-8 md:mt-10">
+          <BlogFeaturedCard
+            item={featured}
+            locale={locale}
+            readArticleLabel={readArticleLabel}
+          />
+        </div>
+      )}
+
+      {rest.length > 0 && (
+        <div className="mt-8 grid grid-cols-1 gap-5 md:mt-10 md:grid-cols-2 lg:grid-cols-3">
+          {rest.map(item => (
+            <BlogCard key={item.slug} item={item} locale={locale} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default BlogIndex;

--- a/src/components/blog/categories.test.ts
+++ b/src/components/blog/categories.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findCategoryBySlug,
+  getAllCategorySlugs,
+  getOrderedCategories,
+  slugifyCategory,
+} from './categories';
+
+describe('slugifyCategory', () => {
+  it('lowercases and replaces spaces with hyphens', () => {
+    expect(slugifyCategory('Inteligência Artificial')).toBe('inteligencia-artificial');
+    expect(slugifyCategory('Web Development')).toBe('web-development');
+  });
+
+  it('strips diacritics', () => {
+    expect(slugifyCategory('Gestão')).toBe('gestao');
+    expect(slugifyCategory('São Paulo')).toBe('sao-paulo');
+  });
+
+  it('collapses consecutive separators and trims edges', () => {
+    expect(slugifyCategory('  Foo --  Bar  ')).toBe('foo-bar');
+    expect(slugifyCategory('!!!Tech!!!')).toBe('tech');
+  });
+
+  it('returns empty string for non-alphanumeric input', () => {
+    expect(slugifyCategory('!!!')).toBe('');
+    expect(slugifyCategory('   ')).toBe('');
+  });
+});
+
+describe('getOrderedCategories', () => {
+  it('preserves first-seen order and dedupes by slug', () => {
+    const posts = [
+      { category: 'Produto' },
+      { category: 'Design' },
+      { category: 'Produto' },
+      { category: 'Inteligência Artificial' },
+    ];
+    expect(getOrderedCategories(posts)).toEqual([
+      { slug: 'produto', label: 'Produto' },
+      { slug: 'design', label: 'Design' },
+      { slug: 'inteligencia-artificial', label: 'Inteligência Artificial' },
+    ]);
+  });
+
+  it('skips posts without a category', () => {
+    const posts = [
+      { category: undefined },
+      { category: 'Produto' },
+      { category: undefined },
+    ];
+    expect(getOrderedCategories(posts)).toEqual([
+      { slug: 'produto', label: 'Produto' },
+    ]);
+  });
+
+  it('keeps the label of the first post that introduced the category', () => {
+    // Same slug, different casing — the first label wins.
+    const posts = [{ category: 'IA' }, { category: 'ia' }];
+    expect(getOrderedCategories(posts)).toEqual([{ slug: 'ia', label: 'IA' }]);
+  });
+});
+
+describe('findCategoryBySlug', () => {
+  it('returns the matching category', () => {
+    const posts = [{ category: 'Produto' }, { category: 'Design' }];
+    expect(findCategoryBySlug(posts, 'design')).toEqual({ slug: 'design', label: 'Design' });
+  });
+
+  it('returns undefined for unknown slugs', () => {
+    expect(findCategoryBySlug([{ category: 'Produto' }], 'design')).toBeUndefined();
+  });
+});
+
+describe('getAllCategorySlugs', () => {
+  it('returns slugs in first-seen order', () => {
+    const posts = [
+      { category: 'Produto' },
+      { category: 'Inteligência Artificial' },
+      { category: 'Design' },
+    ];
+    expect(getAllCategorySlugs(posts)).toEqual([
+      'produto',
+      'inteligencia-artificial',
+      'design',
+    ]);
+  });
+});

--- a/src/components/blog/categories.ts
+++ b/src/components/blog/categories.ts
@@ -1,0 +1,44 @@
+import type { BlogPost } from '@/types/blog';
+
+export type BlogCategoryRef = {
+  slug: string;
+  label: string;
+};
+
+// Unicode "Nonspacing Mark" category — the combining diacritics produced by NFD.
+const DIACRITICS = /\p{Mn}/gu;
+
+export const slugifyCategory = (label: string) =>
+  label
+    .normalize('NFD')
+    .replace(DIACRITICS, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+export const getOrderedCategories = (posts: Pick<BlogPost, 'category'>[]): BlogCategoryRef[] => {
+  const seen = new Set<string>();
+  const ordered: BlogCategoryRef[] = [];
+  for (const post of posts) {
+    if (!post.category) {
+      continue;
+    }
+    const slug = slugifyCategory(post.category);
+    if (seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+    ordered.push({ slug, label: post.category });
+  }
+  return ordered;
+};
+
+export const findCategoryBySlug = (
+  posts: Pick<BlogPost, 'category'>[],
+  slug: string,
+): BlogCategoryRef | undefined =>
+  getOrderedCategories(posts).find(category => category.slug === slug);
+
+export const getAllCategorySlugs = (posts: Pick<BlogPost, 'category'>[]): string[] =>
+  getOrderedCategories(posts).map(category => category.slug);

--- a/src/components/blog/formatDate.ts
+++ b/src/components/blog/formatDate.ts
@@ -1,0 +1,21 @@
+export const formatShortDate = (iso: string, locale: string) => {
+  const date = new Date(iso);
+  const day = new Intl.DateTimeFormat(locale === 'pt-BR' ? 'pt-BR' : 'en-US', {
+    day: 'numeric',
+  }).format(date);
+  const month = new Intl.DateTimeFormat(locale === 'pt-BR' ? 'pt-BR' : 'en-US', {
+    month: 'short',
+  })
+    .format(date)
+    .replace('.', '')
+    .toUpperCase();
+  return `${day} ${month}`;
+};
+
+export const formatLongDate = (iso: string, locale: string) => {
+  return new Intl.DateTimeFormat(locale === 'pt-BR' ? 'pt-BR' : 'en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(new Date(iso));
+};

--- a/src/components/blog/index.ts
+++ b/src/components/blog/index.ts
@@ -1,0 +1,17 @@
+export { default as BlogArticleBody } from './BlogArticleBody';
+export type { BlogCardItem } from './BlogCard';
+export { default as BlogCard } from './BlogCard';
+export { ALL_SLUG, default as BlogCategoryTabs } from './BlogCategoryTabs';
+export { default as BlogFeaturedCard } from './BlogFeaturedCard';
+export { default as BlogFooter } from './BlogFooter';
+export { default as BlogHeader } from './BlogHeader';
+export { default as BlogHero } from './BlogHero';
+export { default as BlogIndex } from './BlogIndex';
+export type { BlogCategoryRef } from './categories';
+export {
+  findCategoryBySlug,
+  getAllCategorySlugs,
+  getOrderedCategories,
+  slugifyCategory,
+} from './categories';
+export { formatLongDate, formatShortDate } from './formatDate';

--- a/src/components/landing-v2/Navbar.tsx
+++ b/src/components/landing-v2/Navbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { motion, useMotionValueEvent, useScroll } from 'motion/react';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
@@ -43,6 +44,9 @@ const NavLinkItem = ({ href, className, onClick, children }: {
   );
 };
 
+const HIDE_AFTER = 80;
+const FADE_LOCALE_AFTER = 24;
+
 const V2Navbar = ({
   links,
   ctaLabel,
@@ -50,53 +54,83 @@ const V2Navbar = ({
 }: V2NavbarProps) => {
   const t = useTranslations('Navbar');
   const [menuOpen, setMenuOpen] = useState(false);
+  const [hidden, setHidden] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+  const { scrollY } = useScroll();
+
+  useMotionValueEvent(scrollY, 'change', (latest) => {
+    const previous = scrollY.getPrevious() ?? 0;
+    const goingDown = latest > previous;
+    setHidden(latest > HIDE_AFTER && goingDown);
+    setScrolled(latest > FADE_LOCALE_AFTER);
+  });
 
   const resolvedLinks = links ?? [
     { label: t('home'), href: '/' },
     { label: t('about'), href: '/sobre-nos' },
     { label: t('services'), href: '/#Servicos' },
     { label: t('portfolio'), href: '/portfolio' },
+    { label: t('blog'), href: '/blog' },
   ];
   const resolvedCtaLabel = ctaLabel ?? t('cta');
 
-  return (
-    <nav className="fixed inset-x-0 top-0 z-50 px-4 pt-4 sm:px-6">
-      <div className="mx-auto flex max-w-6xl items-center justify-between rounded-full border border-white/10 bg-black/10 px-5 py-3 shadow-sm backdrop-blur-md">
-        <Link href="/" className="flex items-center gap-2.5">
-          <Image src="/assets/images/logo/logo_symbol_white.svg" alt="Agility" width={28} height={28} />
-          <Image src="/assets/images/logo/logo_name_white.svg" alt="Agility" width={90} height={24} className="hidden sm:block" />
-        </Link>
-        <div className="flex items-center gap-4">
-          <div className="hidden items-center gap-8 md:flex">
-            {resolvedLinks.map(link => (
-              <NavLinkItem
-                key={link.href}
-                href={link.href}
-                className="text-sm font-medium text-white/60 transition-colors hover:text-white"
-              >
-                {link.label}
-              </NavLinkItem>
-            ))}
-          </div>
+  const shouldHide = hidden && !menuOpen;
 
-          <div className="flex items-center gap-3">
-            <LocaleSwitcher className="hidden sm:flex" />
-            <NavLinkItem
-              href={ctaHref}
-              className="rounded-full bg-primaryDark px-5 py-2 text-sm font-semibold text-white transition-all hover:bg-primary/90 hover:shadow-lg hover:shadow-primary/20"
-            >
-              {resolvedCtaLabel}
-            </NavLinkItem>
-            <button
-              className="flex size-9 items-center justify-center rounded-full border border-white/10 text-white md:hidden"
-              onClick={() => setMenuOpen(!menuOpen)}
-              type="button"
-              aria-label="Menu"
-            >
-              {menuOpen ? '✕' : '☰'}
-            </button>
+  return (
+    <motion.nav
+      className="fixed inset-x-0 top-0 z-50 px-4 pt-4 sm:px-6"
+      initial={{ y: -120, opacity: 0 }}
+      animate={{ y: shouldHide ? -120 : 0, opacity: 1 }}
+      transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+    >
+      <div className="relative mx-auto max-w-6xl">
+        <div className="flex w-full items-center justify-between rounded-full border border-white/10 bg-black/10 px-5 py-3 shadow-sm backdrop-blur-md">
+          <Link href="/" className="flex items-center gap-2.5">
+            <Image src="/assets/images/logo/logo_symbol_white.svg" alt="Agility" width={28} height={28} />
+            <Image src="/assets/images/logo/logo_name_white.svg" alt="Agility" width={90} height={24} className="hidden sm:block" />
+          </Link>
+          <div className="flex items-center gap-4">
+            <div className="hidden items-center gap-8 md:flex">
+              {resolvedLinks.map(link => (
+                <NavLinkItem
+                  key={link.href}
+                  href={link.href}
+                  className="text-sm font-medium text-white/60 transition-colors hover:text-white"
+                >
+                  {link.label}
+                </NavLinkItem>
+              ))}
+            </div>
+
+            <div className="flex items-center gap-3">
+              <LocaleSwitcher className="hidden sm:flex xl:hidden" />
+              <NavLinkItem
+                href={ctaHref}
+                className="rounded-full bg-primaryDark px-5 py-2 text-sm font-semibold text-white transition-all hover:bg-primary/90 hover:shadow-lg hover:shadow-primary/20"
+              >
+                {resolvedCtaLabel}
+              </NavLinkItem>
+              <button
+                className="flex size-9 items-center justify-center rounded-full border border-white/10 text-white md:hidden"
+                onClick={() => setMenuOpen(!menuOpen)}
+                type="button"
+                aria-label="Menu"
+              >
+                {menuOpen ? '✕' : '☰'}
+              </button>
+            </div>
           </div>
         </div>
+
+        <motion.div
+          className="absolute left-full top-1/2 ml-3 hidden -translate-y-1/2 xl:block"
+          animate={{ opacity: scrolled ? 0 : 1, x: scrolled ? 8 : 0 }}
+          transition={{ duration: 0.25, ease: 'easeOut' }}
+          style={{ pointerEvents: scrolled ? 'none' : 'auto' }}
+          aria-hidden={scrolled}
+        >
+          <LocaleSwitcher />
+        </motion.div>
       </div>
 
       {menuOpen && (
@@ -116,7 +150,7 @@ const V2Navbar = ({
           </div>
         </div>
       )}
-    </nav>
+    </motion.nav>
   );
 };
 

--- a/src/data/blog.json
+++ b/src/data/blog.json
@@ -1,0 +1,183 @@
+[
+  {
+    "slug": "como-escolher-um-parceiro-de-tecnologia",
+    "title": "Como escolher um parceiro de tecnologia que entrega de verdade",
+    "excerpt": "Critérios práticos para avaliar fornecedores de software antes de assinar contrato e evitar projetos que estouram prazo, escopo e orçamento.",
+    "coverImage": "https://placehold.co/1600x900/0a0a0a/FD512E/png?text=Tech+Partner",
+    "coverAlt": "Time discutindo arquitetura em sala iluminada",
+    "publishedAt": "2026-05-12",
+    "readingTimeMinutes": 7,
+    "category": "Gestão",
+    "tags": [
+      "estratégia",
+      "fornecedores",
+      "produto"
+    ],
+    "author": {
+      "name": "Equipe Agility",
+      "role": "Editorial",
+      "avatar": "/assets/images/logo/logo_symbol_white.svg"
+    },
+    "body": [
+      {
+        "type": "paragraph",
+        "text": "Contratar um time de tecnologia é uma das decisões mais caras que uma empresa toma — e uma das que mais geram arrependimento quando feita no impulso. Este guia compila os critérios que mais previnem dor de cabeça em projetos de software."
+      },
+      {
+        "type": "heading",
+        "level": 2,
+        "text": "Comece pelo problema, não pela tecnologia"
+      },
+      {
+        "type": "paragraph",
+        "text": "Antes de pedir orçamento, escreva em uma frase qual problema você quer resolver e qual métrica vai mover. Se o fornecedor começar respondendo com stack antes de entender o problema, é sinal de alerta."
+      },
+      {
+        "type": "heading",
+        "level": 2,
+        "text": "Cinco perguntas que separam parceiros de prestadores"
+      },
+      {
+        "type": "list",
+        "ordered": true,
+        "items": [
+          "Como vocês decidem o escopo do MVP?",
+          "O que acontece se a prioridade mudar no meio do projeto?",
+          "Quem do time atende em qual sprint — e por quanto tempo?",
+          "Como vocês medem qualidade além de testes automatizados?",
+          "Vocês conseguem rodar o projeto sozinhos depois do go-live?"
+        ]
+      },
+      {
+        "type": "quote",
+        "text": "Um bom parceiro de tecnologia é aquele que diz não para o cliente quando o pedido vai contra o objetivo de negócio.",
+        "cite": "Renan Martins"
+      },
+      {
+        "type": "heading",
+        "level": 2,
+        "text": "Sinais de alerta antes de assinar"
+      },
+      {
+        "type": "paragraph",
+        "text": "Propostas longas, vagas e cheias de jargão geralmente escondem ausência de processo. Prefira propostas que mostrem entregáveis claros por sprint e uma definição honesta de pronto."
+      },
+      {
+        "type": "paragraph",
+        "text": "Por fim, peça referências e ligue para elas. Conversar 15 minutos com um cliente atual diz mais do que qualquer apresentação comercial."
+      }
+    ]
+  },
+  {
+    "slug": "mvp-em-30-dias-o-que-cabe-e-o-que-nao-cabe",
+    "title": "MVP em 30 dias: o que cabe e o que não cabe",
+    "excerpt": "Como escopar um produto mínimo viável que pode ir ao ar em um mês sem virar um Frankenstein difícil de manter.",
+    "coverImage": "https://placehold.co/1600x900/0a0a0a/4F46E5/png?text=MVP+30+Days",
+    "coverAlt": "Pessoa desenhando wireframes em um notebook",
+    "publishedAt": "2026-04-28",
+    "readingTimeMinutes": 5,
+    "category": "Produto",
+    "tags": [
+      "mvp",
+      "discovery",
+      "lean"
+    ],
+    "author": {
+      "name": "Equipe Agility",
+      "role": "Editorial",
+      "avatar": "/assets/images/logo/logo_symbol_white.svg"
+    },
+    "body": [
+      {
+        "type": "paragraph",
+        "text": "Trinta dias é tempo suficiente para validar uma hipótese, não para construir um produto completo. A diferença entre um MVP útil e um protótipo descartável está em escolher bem o que não fazer."
+      },
+      {
+        "type": "heading",
+        "level": 2,
+        "text": "O que precisa estar dentro"
+      },
+      {
+        "type": "list",
+        "items": [
+          "Uma única jornada feliz, ponta a ponta",
+          "Autenticação suficiente para identificar usuários reais",
+          "Telemetria mínima para medir a métrica que importa",
+          "Forma de coletar feedback qualitativo no produto"
+        ]
+      },
+      {
+        "type": "heading",
+        "level": 2,
+        "text": "O que pode ficar para depois"
+      },
+      {
+        "type": "list",
+        "items": [
+          "Painel administrativo robusto — planilha resolve no começo",
+          "Recuperação de senha por e-mail — login social cobre",
+          "Onboarding com tour guiado — o usuário aprende usando",
+          "Internacionalização — defina o idioma do mercado-alvo"
+        ]
+      },
+      {
+        "type": "paragraph",
+        "text": "Se a equipe estiver tentada a adicionar tudo isso \"porque é simples\", lembre que cada feature opcional é um vetor de bug, manutenção e distração até o lançamento."
+      }
+    ]
+  },
+  {
+    "slug": "design-system-para-times-pequenos",
+    "title": "Design system para times pequenos: por onde começar",
+    "excerpt": "Você não precisa ser a Atlassian para colher os benefícios de um design system. Veja o caminho mínimo para um time de até 10 pessoas.",
+    "coverImage": "https://placehold.co/1600x900/0a0a0a/EC4899/png?text=Design+System",
+    "coverAlt": "Componentes de interface organizados em grid",
+    "publishedAt": "2026-04-10",
+    "readingTimeMinutes": 6,
+    "category": "Design",
+    "tags": [
+      "design system",
+      "tokens",
+      "ui"
+    ],
+    "author": {
+      "name": "Equipe Agility",
+      "role": "Editorial",
+      "avatar": "/assets/images/logo/logo_symbol_white.svg"
+    },
+    "body": [
+      {
+        "type": "paragraph",
+        "text": "Design system não é projeto à parte, é consequência de produto bem cuidado. Em times pequenos, ele nasce do código existente — não de uma biblioteca paralela."
+      },
+      {
+        "type": "heading",
+        "level": 2,
+        "text": "Comece pelos tokens"
+      },
+      {
+        "type": "paragraph",
+        "text": "Cores, espaçamentos, raios e tipografia. Centralize esses valores em variáveis antes de criar qualquer componente novo. Você ganha consistência sem precisar de governança."
+      },
+      {
+        "type": "heading",
+        "level": 2,
+        "text": "Componentes que pagam o investimento primeiro"
+      },
+      {
+        "type": "list",
+        "ordered": true,
+        "items": [
+          "Botão (todas as variantes em um único lugar)",
+          "Campo de formulário com mensagens de erro",
+          "Modal e diálogo de confirmação",
+          "Toast / notificação"
+        ]
+      },
+      {
+        "type": "paragraph",
+        "text": "Esses quatro respondem por 70% das telas em produtos B2B. Resolvendo bem, o resto do design system pode crescer organicamente."
+      }
+    ]
+  }
+]

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
     "about": "About",
     "services": "Services",
     "portfolio": "Portfolio",
+    "blog": "Blog",
     "cta": "Contact us"
   },
   "Footer": {
@@ -189,6 +190,31 @@
     "portfolio_agility_description": "Complete brand identity modernization — logo, typography, and color palette to reposition the brand.",
     "portfolio_dynotest_category": "Corporate Website",
     "portfolio_dynotest_description": "Website for brand positioning with WhatsApp integration for direct contact and increased conversions."
+  },
+  "BlogPage": {
+    "badge": "Agility Blog",
+    "titlePrefix": "Tech, AI and ideas",
+    "titleHighlight": "worth your time",
+    "subtitle": "AI news, hands-on product tutorials, curious tech finds, and behind-the-scenes from the Agility team — written for engineers who want depth and for everyone else who just wants to keep up.",
+    "readingTimeSuffix": "min read",
+    "allLabel": "All",
+    "readArticle": "Read article",
+    "empty": "No posts in this category yet — come back soon."
+  },
+  "BlogCategory": {
+    "eyebrowPrefix": "Category",
+    "titlePrefix": "All articles on",
+    "subtitle": "Everything we've published about {category} — quick reads, deep dives, and what we're learning along the way, for both technical readers and the simply curious.",
+    "metaDescription": "Articles by the Agility team about {category} — news, tutorials, and breakdowns for both technical readers and curious newcomers.",
+    "notFound": "Category not found",
+    "breadcrumbBlog": "Blog"
+  },
+  "BlogDetail": {
+    "notFound": "Article not found",
+    "breadcrumbBlog": "Blog",
+    "readingTimeSuffix": "min read",
+    "byPrefix": "By",
+    "backToBlog": "Back to all articles"
   },
   "PortfolioDetail": {
     "notFound": "Project not found",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -4,6 +4,7 @@
     "about": "Sobre",
     "services": "Serviços",
     "portfolio": "Portfólio",
+    "blog": "Blog",
     "cta": "Fale conosco"
   },
   "Footer": {
@@ -189,6 +190,31 @@
     "portfolio_agility_description": "Modernização completa da identidade visual — logo, tipografia e paleta de cores para reposicionar a marca.",
     "portfolio_dynotest_category": "Site Corporativo",
     "portfolio_dynotest_description": "Site para posicionamento de marca com integração WhatsApp para contato direto e aumento de conversões."
+  },
+  "BlogPage": {
+    "badge": "Blog da Agility",
+    "titlePrefix": "Tecnologia, IA e ideias",
+    "titleHighlight": "que importam",
+    "subtitle": "Novidades de inteligência artificial, tutoriais de produto, curiosidades de tecnologia e bastidores da Agility — em uma linguagem que serve tanto para quem programa quanto para quem só quer entender o que está acontecendo.",
+    "readingTimeSuffix": "min de leitura",
+    "allLabel": "Todos",
+    "readArticle": "Leia o artigo",
+    "empty": "Ainda não temos posts nessa categoria — volte em breve."
+  },
+  "BlogCategory": {
+    "eyebrowPrefix": "Categoria",
+    "titlePrefix": "Tudo sobre",
+    "subtitle": "Tudo que publicamos sobre {category} — leituras rápidas, mergulhos profundos e o que aprendemos pelo caminho, para quem é da área e para quem só tem curiosidade.",
+    "metaDescription": "Artigos do time da Agility sobre {category} — novidades, tutoriais e análises para o público tech e para curiosos que querem se manter por dentro.",
+    "notFound": "Categoria não encontrada",
+    "breadcrumbBlog": "Blog"
+  },
+  "BlogDetail": {
+    "notFound": "Artigo não encontrado",
+    "breadcrumbBlog": "Blog",
+    "readingTimeSuffix": "min de leitura",
+    "byPrefix": "Por",
+    "backToBlog": "Voltar para todos os artigos"
   },
   "PortfolioDetail": {
     "notFound": "Projeto não encontrado",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,6 +19,12 @@ export default function middleware(
   request: NextRequest,
   event: NextFetchEvent,
 ) {
+  // API routes carry their own auth (e.g. /api/blog uses bearer token).
+  // Don't let next-intl rewrite them to a localized page path.
+  if (request.nextUrl.pathname.startsWith('/api/')) {
+    return;
+  }
+
   // Run Clerk middleware only when it's necessary
   if (
     request.nextUrl.pathname.includes('/sign-in')

--- a/src/templates/BlogTemplate.tsx
+++ b/src/templates/BlogTemplate.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { AnimatePresence, motion } from 'motion/react';
+
+import BlogFooter from '@/components/blog/BlogFooter';
+import BlogHeader from '@/components/blog/BlogHeader';
+import { usePathname } from '@/libs/i18nNavigation';
+
+const BlogTemplate = ({ children }: { children: React.ReactNode }) => {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white font-poppins text-neutral-900 antialiased">
+      <BlogHeader />
+      <AnimatePresence mode="wait">
+        <motion.main
+          key={pathname}
+          className="flex-1"
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.3, ease: 'easeInOut' as const }}
+        >
+          {children}
+        </motion.main>
+      </AnimatePresence>
+      <BlogFooter />
+    </div>
+  );
+};
+
+export default BlogTemplate;

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,0 +1,28 @@
+export type BlogAuthor = {
+  name: string;
+  avatar?: string;
+  role?: string;
+};
+
+export type BlogBodyBlock
+  = | { type: 'paragraph'; text: string }
+    | { type: 'heading'; level: 2 | 3; text: string }
+    | { type: 'list'; ordered?: boolean; items: string[] }
+    | { type: 'quote'; text: string; cite?: string }
+    | { type: 'image'; src: string; alt: string; caption?: string }
+    | { type: 'code'; language?: string; code: string };
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+  excerpt: string;
+  coverImage?: string;
+  coverAlt?: string;
+  publishedAt: string;
+  updatedAt?: string;
+  readingTimeMinutes?: number;
+  category?: string;
+  tags?: string[];
+  author?: BlogAuthor;
+  body: BlogBodyBlock[];
+};


### PR DESCRIPTION
## Summary
- **Light-themed blog** with dedicated header/footer/template (`/blog`, `/blog/[slug]`, `/blog/category/[slug]`) — Poppins typography matching the main site, Google-blog-inspired layout (category tabs, featured card, compact grid).
- **AI-agent content API** at `POST /api/blog` (list / read / create / update) — bearer-token auth using a 32-char MD5 in `BLOG_API_TOKEN`, zod validation, atomic JSON-file storage, full reference at `src/app/api/blog/context.md`.
- **SEO hardening across the blog**: per-page `buildAlternates` (canonical + hreflang + x-default), OG/Twitter metadata, JSON-LD (`Blog` on index, `CollectionPage`+`ItemList` on category, `BlogPosting` on article), sitemap rows for `/blog`, every article, and every category — all bilingual (pt-BR + en).
- **Marketing copy** rewritten for the broader audience (tech + AI news + curiosities for both technical and general readers).
- **Main-site nav polish**: smooth fade-in + scroll-direction show/hide animation, locale switcher relocated outside the pill at xl+ with scroll-fade.

## Notable extras
- `LocaleSwitcher` now takes a `theme: 'light' | 'dark'` prop so the same component serves both shells.
- `/api/*` paths bypass `next-intl` middleware (was rewriting API requests to localized pages → 404).
- New `BlogCategoryTabs` uses link-based routing (SEO-friendly) with active-tab underline and hidden horizontal scrollbar.
- Articles persist to `src/data/blog.json` via atomic write-then-rename. **No DB** — production deployment on a read-only serverless platform will require swapping `readPosts` / `writePosts` for a real datastore. Caveat documented in `context.md` §8.

## Test plan
- [x] `npx vitest run` → **114/114 passing across 24 files**
- [x] `npx tsc --noEmit` clean
- [x] End-to-end API smoke: 401 (no/wrong token), 400 (invalid JSON / unknown action / bad payload / slug-in-patch), 200 list (filters + pagination), 200 read, 404 read-missing, 201 create (auto-slug + auto-reading-time), 409 slug-conflict, 200 update (merge + updatedAt bump), 404 update-missing
- [x] Routes verified against dev server: `/blog`, `/en/blog`, `/blog/category/{produto,design,gestao}`, `/en/blog/category/design`, `/blog/<slug>`, `/blog/category/does-not-exist` → 404
- [x] SEO output verified in HTML: canonical, hreflang (pt-BR / en / x-default), og:* and twitter:* on listing + category pages
- [x] Sitemap contains all blog + category URLs per locale

## Setup notes
- Real token lives in `.env.local` (gitignored). `.env` has a placeholder + generator one-liner. To rotate:
  ```bash
  node -e "console.log(require('crypto').createHash('md5').update(require('crypto').randomBytes(32)).digest('hex'))"
  ```