### PR TITLE
feat(i18n): default to pt-BR, persist locale choice in cookie + localStorage

### DIFF
--- a/src/components/LocaleSwitcher/LocaleSwitcher.test.tsx
+++ b/src/components/LocaleSwitcher/LocaleSwitcher.test.tsx
@@ -1,7 +1,30 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import LocaleSwitcher from './LocaleSwitcher';
+
+// jsdom in this project doesn't ship a functional localStorage — stub one.
+const buildStorage = (): Storage => {
+  const store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+      }
+    },
+    getItem: (key: string) => (key in store ? store[key]! : null),
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+  };
+};
 
 const replaceSpy = vi.fn();
 
@@ -17,6 +40,22 @@ vi.mock('next-intl', () => ({
   useLocale: () => 'pt-BR',
 }));
 
+beforeEach(() => {
+  replaceSpy.mockClear();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: buildStorage(),
+  });
+  // jsdom carries cookies between tests; clear them.
+  document.cookie
+    .split(';')
+    .map(c => c.split('=')[0]?.trim())
+    .filter(Boolean)
+    .forEach((name) => {
+      document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    });
+});
+
 describe('LocaleSwitcher', () => {
   it('renders a button per locale with the active one marked pressed', () => {
     render(<LocaleSwitcher />);
@@ -29,7 +68,6 @@ describe('LocaleSwitcher', () => {
   });
 
   it('calls router.replace with the same pathname and the chosen locale', () => {
-    replaceSpy.mockClear();
     render(<LocaleSwitcher />);
     const enButton = screen.getByRole('button', { name: /Switch to English/i });
     fireEvent.click(enButton);
@@ -37,9 +75,22 @@ describe('LocaleSwitcher', () => {
   });
 
   it('does nothing when the active locale is clicked', () => {
-    replaceSpy.mockClear();
     render(<LocaleSwitcher />);
     fireEvent.click(screen.getByRole('button', { name: /português/i }));
     expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('persists the chosen locale to localStorage and the NEXT_LOCALE cookie', () => {
+    render(<LocaleSwitcher />);
+    fireEvent.click(screen.getByRole('button', { name: /Switch to English/i }));
+    expect(window.localStorage.getItem('preferredLocale')).toBe('en');
+    expect(document.cookie).toContain('NEXT_LOCALE=en');
+  });
+
+  it('does not write to storage when the click is a no-op', () => {
+    render(<LocaleSwitcher />);
+    fireEvent.click(screen.getByRole('button', { name: /português/i }));
+    expect(window.localStorage.getItem('preferredLocale')).toBeNull();
+    expect(document.cookie).not.toContain('NEXT_LOCALE=');
   });
 });

--- a/src/components/LocaleSwitcher/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher/LocaleSwitcher.tsx
@@ -41,6 +41,24 @@ const THEME_STYLES: Record<LocaleSwitcherTheme, {
   },
 };
 
+// One year — long enough that the choice survives the typical "remember-me"
+// session but short enough that abandoned browsers eventually reset.
+const PREFERRED_LOCALE_TTL_SECONDS = 60 * 60 * 24 * 365;
+
+const persistLocaleChoice = (locale: (typeof AppConfig.locales)[number]) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  // localStorage is per the user's request — handy for client-only reads.
+  try {
+    window.localStorage.setItem('preferredLocale', locale);
+  } catch {
+    // Storage can be blocked (private mode, quota). Fall through to cookie.
+  }
+  // Cookie is what the middleware reads on subsequent SSR requests.
+  document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${PREFERRED_LOCALE_TTL_SECONDS}; samesite=lax`;
+};
+
 const LocaleSwitcher = ({ className, theme = 'dark' }: LocaleSwitcherProps) => {
   const router = useRouter();
   const pathname = usePathname();
@@ -52,6 +70,9 @@ const LocaleSwitcher = ({ className, theme = 'dark' }: LocaleSwitcherProps) => {
     if (nextLocale === activeLocale || isPending) {
       return;
     }
+    // Persist before navigating so the cookie is in flight by the time
+    // the SSR request for the new URL hits the middleware.
+    persistLocaleChoice(nextLocale);
     startTransition(() => {
       router.replace(pathname, { locale: nextLocale });
     });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 import type { NextFetchEvent, NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import createMiddleware from 'next-intl/middleware';
 
 import { AppConfig } from './utils/AppConfig';
@@ -8,12 +9,50 @@ const intlMiddleware = createMiddleware({
   locales: AppConfig.locales,
   localePrefix: AppConfig.localePrefix,
   defaultLocale: AppConfig.defaultLocale,
+  // Default-locale-first: never auto-pick from Accept-Language. Brazilian
+  // visitors land in pt-BR even when their browser advertises en-US; English
+  // is opt-in via the locale switcher (which sets the NEXT_LOCALE cookie
+  // that takes over on subsequent visits — see localePreferredRedirect below).
+  localeDetection: false,
 });
 
 const isProtectedRoute = createRouteMatcher([
   '/dashboard(.*)',
   '/:locale/dashboard(.*)',
 ]);
+
+// Locale-prefix detection. With `localePrefix: 'as-needed'` only non-default
+// locales appear in the URL.
+const nonDefaultLocales = AppConfig.locales.filter(
+  locale => locale !== AppConfig.defaultLocale,
+);
+
+const hasLocalePrefix = (pathname: string) =>
+  nonDefaultLocales.some(
+    locale => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`),
+  );
+
+// If the visitor previously chose a non-default locale (stored in the
+// NEXT_LOCALE cookie by the LocaleSwitcher), promote that choice to a real
+// redirect so the rest of the pipeline — and search engines — see the locale.
+const localePreferredRedirect = (request: NextRequest) => {
+  const { pathname, search } = request.nextUrl;
+  if (hasLocalePrefix(pathname)) {
+    return null;
+  }
+  const cookieLocale = request.cookies.get('NEXT_LOCALE')?.value;
+  if (
+    !cookieLocale
+    || cookieLocale === AppConfig.defaultLocale
+    || !(AppConfig.locales as readonly string[]).includes(cookieLocale)
+  ) {
+    return null;
+  }
+  const url = request.nextUrl.clone();
+  url.pathname = `/${cookieLocale}${pathname === '/' ? '' : pathname}`;
+  url.search = search;
+  return NextResponse.redirect(url);
+};
 
 export default function middleware(
   request: NextRequest,
@@ -23,6 +62,12 @@ export default function middleware(
   // Don't let next-intl rewrite them to a localized page path.
   if (request.nextUrl.pathname.startsWith('/api/')) {
     return;
+  }
+
+  // Honor a stored locale preference before any locale-routing logic kicks in.
+  const preferred = localePreferredRedirect(request);
+  if (preferred) {
+    return preferred;
   }
 
   // Run Clerk middleware only when it's necessary


### PR DESCRIPTION
> Stacked on top of #43. Change base to \`main\` (or just merge #43 first) once that one ships.

## Summary
- **No more Accept-Language auto-detection.** \`localeDetection: false\` on the next-intl middleware — every fresh visit lands in **pt-BR**, even when the browser advertises \`en-US\`. English is opt-in via the flag.
- **LocaleSwitcher now persists the choice** to both \`localStorage.preferredLocale\` (per the request) **and** a \`NEXT_LOCALE\` cookie (1-year max-age, \`SameSite=Lax\`).
- **Middleware honors the cookie on subsequent SSR requests**: if the URL has no locale prefix and the cookie says a non-default locale, we 307-redirect to the prefixed path (e.g. \`/\` → \`/en\`, \`/portfolio\` → \`/en/portfolio\`). Explicit URL prefix always wins (e.g. \`/en/portfolio\` with cookie \`pt-BR\` stays in English).

## Why both localStorage and a cookie?
- localStorage is what you asked for — handy for client-only logic and surveys.
- The cookie is what the **server** can read in middleware; without it we'd flash pt-BR before the client could redirect. The cookie does the SSR work; localStorage stays available for any client-side use later.

## Test plan
- [x] \`npx vitest run\` → 116/116 passing across 24 files (added 2 new tests in \`LocaleSwitcher.test.tsx\`)
- [x] \`npx tsc --noEmit\` clean
- [x] Smoke against dev server:
  - \`GET /\` (no cookie) → 200, pt-BR ✓
  - \`GET /\` with \`Accept-Language: en-US\` (no cookie) → 200, **pt-BR** (no auto-redirect) ✓
  - \`GET /\` with cookie \`NEXT_LOCALE=en\` → 307 → \`/en\` ✓
  - \`GET /portfolio\` with cookie \`NEXT_LOCALE=en\` → 307 → \`/en/portfolio\` ✓
  - \`GET /en/portfolio\` with cookie \`NEXT_LOCALE=pt-BR\` → 200, English (URL prefix wins) ✓
  - \`GET /\` with cookie \`NEXT_LOCALE=pt-BR\` → 200, no redirect (matches default) ✓