### PR TITLE
feat(blog): Postgres storage, draft/publish/delete + upload, UI polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,12 @@ local
 
 # vercel
 .vercel
+
+# blog bot secrets & runtime
+bot/.secret-token
+bot/.slack-webhook
+bot/rascunhos/
+bot/queue/*.json
+bot/published/
+bot/failed/
+bot/*.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Project notes & preferences
+
+## ⚠️ Deletion policy (strict)
+**Never delete any file or folder unless the user explicitly says "APPROVE DELETE".**
+This applies to all delete operations (rm, mv-to-trash, file-delete tools, etc.).
+If a deletion seems needed, ask and wait for the exact phrase "APPROVE DELETE" first.
+
+## Blog bot
+See `bot/README.md`. Daily PT-BR tech-article bot: Cowork scheduled task writes a ready
+article to `bot/queue/`; a local launchd publisher (`bot/publish.mjs`) POSTs to the
+Agility blog API and notifies Slack `#agility-creative`.

--- a/PLANO-bot-blog-tech.md
+++ b/PLANO-bot-blog-tech.md
@@ -1,0 +1,182 @@
+# Plano: Bot autônomo de artigos de tecnologia (PT-BR)
+
+> Documento de planejamento — **nada será construído ainda**. Objetivo: mapear requisitos, arquitetura, features e o que falta para começar.
+
+---
+
+## 1. Visão geral
+
+Um bot que, **todo dia**, automaticamente:
+
+1. Lê os posts recentes de uma lista de blogs de tecnologia.
+2. Identifica os tópicos mais interessantes / em alta.
+3. **Cruza informações entre várias fontes** para garantir precisão e evitar cópia.
+4. Escreve **1 artigo de blog em Português (Brasil)**, legível por humanos, com tom editorial.
+5. (Opcional) Gera imagem(ns) de capa/ilustração.
+6. **Envia o artigo para a API do seu site** (endpoint já existente — sem mudar código do site).
+7. Te notifica e permite revogar/editar (modelo híbrido aprovado por você).
+
+### Decisões já tomadas (suas respostas)
+
+| Tema | Decisão |
+|---|---|
+| Runtime / "nuvem" | **Claude Cowork** (tarefa agendada) |
+| API de publicação | **Já existe — você tem a spec** |
+| Motor de IA | **Claude (Anthropic)** — nativo no Cowork |
+| Controle | **Híbrido**: publica automático, te notifica, você pode revogar/editar |
+
+---
+
+## 2. Por que o Cowork muda (simplifica) tudo
+
+Como o bot roda **dentro do Cowork**, você **não precisa** de:
+
+- ❌ Servidor / VPS / container sempre ligado
+- ❌ AWS Lambda, EventBridge, filas
+- ❌ Integração manual com a API do Claude (o Cowork já é o Claude)
+- ❌ Pipeline de CI/CD para o bot
+
+O que o Cowork fornece nativamente:
+
+- ✅ **Agendamento diário** (scheduled task)
+- ✅ **Navegação/busca web** (para ler os blogs e cruzar fontes)
+- ✅ **Escrita do artigo** em PT-BR
+- ✅ **Geração de imagem**
+- ✅ **Conectores** já disponíveis: Slack, Gmail, Google Drive, Google Calendar
+- ✅ **Arquivos no seu workspace** (`agility-app/`) para guardar config e histórico
+
+> Trade-off honesto: uma scheduled task do Cowork é ótima para **1 execução leve por dia**. Não é um sistema de filas industrial. Para "1 artigo/dia" é exatamente o ponto certo. Se um dia você precisar de 50 artigos/hora, aí sim migra para infra dedicada.
+
+---
+
+## 3. Arquitetura proposta
+
+```
+                 ┌─────────────────────────────────────────┐
+                 │   Cowork Scheduled Task (diária, ex: 6h) │
+                 └─────────────────────────────────────────┘
+                                    │
+        ┌───────────────────────────┼───────────────────────────┐
+        ▼                           ▼                           ▼
+ 1. LER CONFIG              2. COLETAR & ANALISAR        3. ESCREVER
+ - sources.json            - fetch dos blogs/RSS         - artigo PT-BR
+ - guia-de-voz.md (intro)  - cruzar 2-3 fontes           - título, slug, SEO
+ - historico.json (dedup)  - escolher 1 tópico novo      - (opcional) imagem
+                                    │
+                                    ▼
+                 4. PUBLICAR via API do site (POST)
+                                    │
+                                    ▼
+                 5. NOTIFICAR (Slack/Email) + opção de revogar
+                                    │
+                                    ▼
+                 6. REGISTRAR em historico.json (evita repetir tópico)
+```
+
+Tudo orquestrado por **um único prompt agendado** + alguns **arquivos de configuração** no seu workspace.
+
+---
+
+## 4. Componentes / features a construir
+
+### 4.1 Arquivos de configuração (no workspace `agility-app/`)
+
+| Arquivo | Conteúdo | Quem fornece |
+|---|---|---|
+| `bot/sources.json` | Lista de blogs (URL + feed RSS quando houver) + peso/prioridade | **Você** (a lista que não chegou) |
+| `bot/guia-de-voz.md` | Tom, persona, público-alvo, do's & don'ts, comprimento | **Você** (a "intro" que não chegou) |
+| `bot/api.json` | Endpoint, método, headers/auth, schema do payload | **Você** (a spec) |
+| `bot/historico.json` | Tópicos/URLs já cobertos (deduplicação) | Gerado pelo bot |
+| `bot/prompt-diario.md` | O prompt mestre que a tarefa agendada executa | Eu construo |
+
+### 4.2 Coleta de conteúdo
+- Preferir **RSS/Atom feeds** quando existirem (mais estável que scraping de HTML).
+- Fallback: busca web + leitura de página.
+- Janela: posts das últimas 24–72h.
+
+### 4.3 Seleção de tópico ("o que é interessante")
+- Critérios configuráveis: recorrência do tema em várias fontes, relevância pro público, ineditismo (não repetir `historico.json`).
+- Cross-check: confirmar fatos em **≥2 fontes independentes** antes de escrever.
+
+### 4.4 Geração do artigo (PT-BR)
+- Estrutura: título, subtítulo, intro, corpo com subtítulos, conclusão, CTA.
+- **Original** — síntese própria, sem copiar parágrafos; citar/linkar fontes.
+- SEO básico: slug, meta description, tags/categoria.
+- Formato de saída: o que a sua API espera (Markdown? HTML? blocos?).
+
+### 4.5 Imagens (opcional)
+- Gerar capa + 0–2 ilustrações.
+- **Ponto a resolver:** sua API aceita **upload de imagem**? Ou espera uma **URL** (precisaria de um host/CDN — ex. Cloudinary, S3, ou o próprio storage do seu site)?
+
+### 4.6 Publicação (API)
+- Cliente faz `POST` no seu endpoint com o payload no schema correto.
+- Tratamento de erro: retry + notificação se falhar.
+
+### 4.7 Notificação + revogação (modelo híbrido)
+- Após publicar, manda **Slack ou e-mail** com: título, link do artigo publicado, resumo e instruções para **editar/despublicar**.
+- "Revogar" depende da sua API ter um endpoint de update/unpublish (ou status `draft`).
+
+### 4.8 Logs e deduplicação
+- `historico.json` guarda tópicos, URLs-fonte e data — evita repetir assunto.
+
+---
+
+## 5. Integração com a API — o que eu preciso de você
+
+Para `bot/api.json`, preciso de:
+
+1. **URL** do endpoint de criação de post.
+2. **Método** (POST/PUT) e **Content-Type**.
+3. **Autenticação**: API key? Bearer token? Onde vai no request (header `Authorization`?).
+4. **Schema do payload** — nomes exatos dos campos. Ex.:
+   - `title`, `slug`, `excerpt`, `content` (Markdown ou HTML?), `coverImage` (URL ou upload?), `tags[]`, `category`, `author`, `status` (`published`/`draft`), `publishedAt`, `lang` (`pt-BR`).
+5. **Imagem**: upload multipart, base64, ou só URL?
+6. **Endpoint de update/unpublish** (para o "revogar").
+7. Um **exemplo de request que funciona** (curl/Postman) — vale ouro.
+
+> ⚠️ **Segurança:** a API key/token será necessária na execução. Vamos definir onde guardá-la com segurança (não commitar em texto puro no repositório). Discutir antes de construir.
+
+---
+
+## 6. O que ainda falta de você (inputs)
+
+| Item | Status |
+|---|---|
+| 📄 Lista de blogs/sites a monitorar | **Não chegou** — reenviar |
+| 📄 "Intro" / guia de voz e público | **Não chegou** — reenviar |
+| 🔌 Spec completa da API (seção 5) | Pendente |
+| 🖼️ Imagens: API aceita upload ou só URL? | Pendente |
+| 🔁 Endpoint de unpublish/edit existe? | Pendente |
+| 📢 Canal de notificação: Slack ou e-mail? | Definir |
+| ⏰ Horário diário da publicação | Definir (ex. 6h) |
+| 🌐 Categoria/tags padrão e autor do post | Definir |
+
+---
+
+## 7. Riscos & mitigações
+
+| Risco | Mitigação |
+|---|---|
+| **Alucinação / fato errado** | Cross-check em ≥2 fontes; modelo híbrido (você revisa); citar fontes |
+| **Plágio / copyright** | Síntese original, sem copiar trechos; sempre linkar a fonte |
+| **Repetir o mesmo tópico** | `historico.json` de deduplicação |
+| **Fonte fora do ar / muda HTML** | Preferir RSS; fallback de busca; pular fonte com erro |
+| **API falhar no POST** | Retry + notificação de falha; salvar rascunho local |
+| **Vazamento da API key** | Armazenamento seguro de segredo (definir) |
+| **Qualidade do PT-BR** | Guia de voz + revisão híbrida nas primeiras semanas |
+
+---
+
+## 8. Rollout em fases (sugerido)
+
+- **Fase 0 — Setup:** você envia sites + intro + spec da API. Eu monto os arquivos de config.
+- **Fase 1 — Dry run (sem publicar):** bot gera 1 artigo e te manda por Slack/e-mail para revisão. Ajustamos tom/qualidade.
+- **Fase 2 — Publicação manual assistida:** bot publica via API quando você aprova.
+- **Fase 3 — Híbrido automático:** agenda diária, publica sozinho, te notifica, você revoga se precisar.
+- **Fase 4 — Imagens + SEO refinado:** adiciona capas geradas e otimização.
+
+---
+
+## 9. Próximo passo
+
+Me reenvie (1) a **lista de sites**, (2) a **intro/guia de voz** e (3) a **spec da API** (seção 5). Com isso eu monto a Fase 0 e fazemos um **dry run** antes de qualquer publicação automática.

--- a/STORAGE-FIX.md
+++ b/STORAGE-FIX.md
@@ -1,0 +1,58 @@
+# Correção: `storage_write_failed` no blog (filesystem → Postgres)
+
+## O problema
+A API `/api/blog` gravava os posts em `src/data/blog.json` (filesystem). Em runtime
+serverless (Vercel/Lambda) o filesystem é **read-only**, então todo `create`/`update`
+falhava com **HTTP 500 `storage_write_failed`**. Leitura funcionava porque o JSON vinha
+embutido no build. As páginas do blog também liam o JSON **estático** (congelado no build),
+então posts novos nem apareceriam.
+
+## O que mudou (já implementado)
+A fonte de verdade agora é **Postgres via Drizzle** (a infra que o projeto já tinha em
+`src/libs/DB.ts`, com fallback PGlite em dev):
+
+- **Novo:** `src/libs/blogStore.ts` — `getPosts` / `getPostsSafe` / `savePosts`.
+- **Schema:** `src/models/Schema.ts` — tabela `blog_store` (uma linha JSONB com o array de posts).
+- **API:** `src/app/api/blog/route.ts` — usa o store em vez de `fs`.
+- **Páginas + sitemap:** leem do store (`getPostsSafe`) e viraram `dynamic = 'force-dynamic'`.
+- **Testes:** `route.test.ts` agora mocka o store (não o `fs`).
+- `src/data/blog.json` continua como **seed**: popula a tabela na primeira leitura e serve de
+  fallback se o banco cair. (Os 3 posts atuais são preservados.)
+
+Validado aqui: `tsc --noEmit` ✅ e ESLint ✅. (Os testes não rodam neste ambiente Linux por
+causa dos binários nativos do `node_modules` compilados no macOS — rode no seu Mac.)
+
+## Passos finais (no seu Mac) — você precisa fazer
+
+1. **Provisione um Postgres** (ex.: Neon free tier ou Vercel Postgres). Copie a connection
+   string. Para Neon, use a string com `?sslmode=require`.
+
+2. **Configure `DATABASE_URL`:**
+   - Produção: nas variáveis de ambiente do host (Vercel → Project → Settings → Environment Variables).
+   - Local (opcional): em `.env.local`. Sem ela, o dev usa PGlite em memória (dados resetam a cada restart — ok para testar).
+
+3. **Gere a migration** (cria a tabela `blog_store`):
+   ```bash
+   npm run db:generate    # cria migrations/0001_*.sql
+   ```
+   Faça commit do arquivo gerado. No deploy, `src/libs/DB.ts` aplica as migrations
+   automaticamente (`migratePg`). Alternativa manual: `npm run db:migrate`.
+
+4. **Rode os checks** no Mac:
+   ```bash
+   npm run check-types   # já passou aqui
+   npm run test          # roda os testes da rota (atualizados)
+   ```
+
+5. **Deploy.** Na primeira leitura, `blog_store` é semeada com o `blog.json` atual.
+   A partir daí o Postgres é a fonte de verdade.
+
+6. **Re-teste o bot:** "Run now" na tarefa agendada (Chrome aberto). O artigo
+   *Microsoft Build 2026* que está na fila será publicado e aparecerá em `/blog`.
+
+## Observações
+- As páginas do blog agora são renderizadas por request (force-dynamic). Se quiser cache,
+  dá para trocar por `revalidate` + `revalidatePath` no futuro.
+- **Upload de imagem** (`/api/blog/upload` → `public/blog/uploads/`) ainda grava em filesystem
+  e teria o mesmo problema no serverless. Hoje não é usado (capas usam URLs do placehold.co).
+  Se um dia for usar upload real, migrar para Blob/S3/R2.

--- a/bot/.secret-token.example
+++ b/bot/.secret-token.example
@@ -1,0 +1,1 @@
+519dd619f1c6d34e0ba4052f8d1e6ccb

--- a/bot/PROMPT-DIARIO.md
+++ b/bot/PROMPT-DIARIO.md
@@ -1,0 +1,181 @@
+# PROMPT DIÁRIO — Bot de artigos do Blog Agility
+
+> Este é o prompt que a **tarefa agendada** executa todo dia. Ele é autossuficiente:
+> lê os arquivos de config desta pasta, coleta e cruza fontes, escreve UM artigo em PT-BR
+> e o **publica via Claude no Chrome** (POST de mesma origem), porque o bash/python deste
+> ambiente não tem rede para a API. Depois avisa no Slack.
+
+Você é o editor automático do Blog Agility. Sua missão hoje: produzir e publicar **1 artigo**
+de tecnologia em Português (Brasil), seguindo as etapas abaixo.
+
+---
+
+## ETAPA 0 — PRIMEIRO: checar a fila (atalho para economizar tokens)
+Antes de qualquer coisa, liste `bot/queue/`.
+
+- **Se houver algum `*.json` pendente na fila:** NÃO pesquise, NÃO leia fontes, NÃO escreva nada
+  novo. Apenas **publique o(s) arquivo(s) pendente(s)** seguindo a Etapa 5 (publicação via
+  Chrome) para cada um. Em sucesso (201), mova o arquivo para `bot/published/`, registre em
+  `historico.json` (`publicados`) e avise no Slack (Etapa 7). Depois **PARE** — não execute as
+  Etapas 1 a 4. (Isso reaproveita um artigo já escrito num dia anterior que não chegou a publicar.)
+- **Se a fila estiver vazia:** siga normalmente a partir da Etapa 0.1 abaixo.
+
+---
+
+## ETAPA 0.1 — Carregar contexto
+Leia, nesta pasta (`bot/`):
+- `guia-de-voz.md` → tom, público e estrutura do artigo. **Siga à risca.**
+- `sources.json` → lista de fontes e pesos.
+- `api.json` → endpoint, formato do payload e restrições.
+- `historico.json` → tópicos já publicados e links já lidos. **Nunca repita** um tópico
+  de `publicados` nem releia um slug/URL de `links_lidos`.
+
+O token da API fica em `bot/.secret-token` (uma linha). Você só o lê na Etapa 5 para injetar
+no `fetch` do Chrome. **Nunca imprima o token** em texto, logs ou no Slack.
+
+---
+
+## ETAPA 1 — Coletar (navegar a homepage de cada fonte)
+Para **cada fonte** em `sources.json`:
+
+1. **Navegue até a homepage** (campo `url`) e identifique os **10 artigos mais novos**
+   (manchetes/cards do topo). Se a homepage não renderizar o conteúdo (página em JS),
+   use busca web restrita ao domínio da fonte para obter as 10 matérias mais recentes.
+2. Para cada artigo, extraia: **título, link (URL), slug, data e um resumo curto**.
+   O slug é o trecho final da URL (ex.: `.../noticias/<slug>/`).
+3. **Deduplicação por slug:** descarte imediatamente qualquer artigo cujo `slug` (ou URL)
+   já esteja registrado em `historico.json` (campo `links_lidos`). **Não leia de novo** o que
+   já foi lido — isso evita reprocessar e repetir tópicos.
+4. Só abra/leia o conteúdo completo dos artigos **inéditos** (que sobraram após o filtro).
+
+Observações práticas:
+- Feeds RSS desses sites costumam vir comprimidos e as homepages são renderizadas em JS;
+  por isso a coleta confiável é **navegar a homepage / buscar no domínio**, não baixar o RSS cru.
+- Registre todos os slugs/URLs vistos hoje para gravar em `historico.json` na Etapa 6.
+
+Monte uma lista de candidatos a tópico (título + resumo + link + slug + fonte), só com inéditos.
+
+---
+
+## ETAPA 2 — Selecionar UM tópico
+Critérios, nesta ordem:
+1. **Ineditismo:** não pode estar em `historico.json` (compare por tema, não só por URL).
+2. **Relevância:** interessa ao público geral E/OU ao público técnico (priorize IA,
+   novidades e aplicação prática no dia a dia — ver `guia-de-voz.md`).
+3. **Cobertura cruzada:** prefira temas que aparecem em **2+ fontes** (sinal de relevância).
+4. Respeite o `weight` de cada fonte como desempate.
+
+Escolha **um** tópico. Anote 2–3 fontes que falam dele.
+
+---
+
+## ETAPA 3 — Cruzar fontes (checagem)
+Antes de escrever, confirme os fatos centrais em **pelo menos 2 fontes independentes**.
+Se um fato aparece em só uma fonte e é duvidoso, não afirme como certo — contextualize
+("segundo a [fonte]..."). O objetivo é precisão e zero invenção.
+
+---
+
+## ETAPA 4 — Escrever o artigo (PT-BR)
+Siga o `guia-de-voz.md`: linguagem simples, meio-termo (nem formal nem gíria), explicando
+termos técnicos, sempre conectando à aplicação no dia a dia. **Texto 100% original** —
+sintetize com palavras próprias, nunca copie trechos. Cite/linke as fontes no corpo.
+
+Produza estes campos:
+- `title` (3–200 chars): claro e atraente, sem clickbait.
+- `excerpt` (10–500 chars): resumo standalone (vira meta description e card). Não repita o lede.
+- `category`: leia o blog ao vivo (GET `https://www.agilitycreative.com/blog`) e veja as abas
+  de categoria existentes. Reuse um label existente quando o tema encaixar. Para conteúdo de
+  tecnologia/novidades que não encaixe nas categorias do blog, use de forma consistente
+  `"Inteligência Artificial"` (temas de IA) ou `"Tecnologia"` (demais). Mantenha o mesmo
+  rótulo todo dia para não criar categorias quase-duplicadas.
+- `tags`: 3–6 palavras simples, sem `#`.
+- `author`: `{ "name": "Equipe Agility", "role": "Editorial" }`.
+- `coverImage`: por enquanto use placeholder:
+  `https://placehold.co/1600x900/0a0a0a/4F46E5/png?text=<tema-curto-url-encoded>`
+- `coverAlt`: descrição curta da capa.
+- `body`: **array de blocos tipados** (NÃO markdown). Tipos válidos: `paragraph`,
+  `heading` (level 2 ou 3), `list` (`items[]`, `ordered?`), `quote` (`text`, `cite?`),
+  `image` (`src`, `alt`, `caption?`), `code` (`code`, `language?`).
+  Estrutura recomendada:
+  1. 1 `paragraph` de lede (não repita o excerpt).
+  2. Conteúdo agrupado sob `heading` level 2 (level 3 para subseções).
+  3. Listas após um parágrafo de contexto.
+  4. Parágrafo final conectando ao leitor + 1 parágrafo com as fontes/links.
+
+---
+
+## ETAPA 5 — Publicar via Claude no Chrome (POST de mesma origem)
+⚠️ Este ambiente (bash/python) **não tem rede para a API** (firewall). O POST é feito pelo
+**navegador**, que roda no Mac e tem rede real. Como a página e a API estão na mesma origem
+(`https://www.agilitycreative.com`), o `fetch` interno **não sofre CORS**.
+
+Prepare o payload:
+```json
+{ "action": "create", "post": { ...campos da Etapa 4... } }
+```
+Defina um `slug` explícito (regex `^[a-z0-9]+(?:-[a-z0-9]+)*$`) derivado do título. Antes,
+confira títulos/slugs já no ar lendo (GET) `https://www.agilitycreative.com/blog` para não repetir.
+
+**Grave o payload na fila**: `bot/queue/<YYYY-MM-DD>-<slug>.json` com `{ "action":"create", "post":{...} }`.
+Manter o arquivo na fila garante que, se a publicação falhar agora, a próxima execução o reaproveita
+(Etapa 0) sem reescrever — economizando tokens.
+
+Publique pelo Chrome:
+1. Leia o token de `bot/.secret-token` (apenas para injetar no fetch; não o imprima em texto).
+2. Navegue o Chrome até `https://www.agilitycreative.com/blog` (precisa ser nessa origem).
+3. Execute via javascript_tool um fetch de mesma origem:
+   ```js
+   const r = await fetch('/api/blog', {
+     method: 'POST',
+     headers: { 'Authorization': 'Bearer ' + TOKEN, 'Content-Type': 'application/json' },
+     body: JSON.stringify(PAYLOAD)
+   });
+   return { status: r.status, body: await r.json() };
+   ```
+4. Trate o retorno:
+   - `201` + `ok:true` → sucesso. Guarde `data.post.slug`, monte o link
+     `https://www.agilitycreative.com/blog/<slug>` e **mova o arquivo da fila para
+     `bot/published/`** (assim ele não é republicado amanhã).
+   - `409 slug_conflict` → o slug já existe no site. Ajuste o slug e tente 1x; persistindo,
+     mova o arquivo para `bot/failed/` e avise no Slack.
+   - `400 invalid_request` → leia `details.fieldErrors`, corrija o arquivo da fila e reenvie.
+   - `401` → token errado: **pare**, NÃO publique, deixe o arquivo na fila e avise no Slack
+     (sem vazar o token).
+   - Falha de rede/Chrome indisponível → **deixe o arquivo na fila** (será reaproveitado na
+     próxima execução pela Etapa 0) e avise a falha no Slack.
+
+---
+
+## ETAPA 6 — Registrar no histórico
+Atualize `historico.json` (dois campos):
+```json
+{
+  "publicados": [ { "data": "<YYYY-MM-DD>", "tema": "...", "slug": "...", "categoria": "..." } ],
+  "links_lidos": ["<url-ou-slug-1>", "<url-ou-slug-2>"]
+}
+```
+- **Só após o POST dar 201**, adicione o artigo em `publicados`.
+- Sempre adicione em `links_lidos` todos os slugs/URLs vistos hoje (mesmo os não usados),
+  para não relê-los amanhã. Mantenha enxuto (~últimos 60 dias).
+
+---
+
+## ETAPA 7 — Notificar no Slack
+Após publicar com sucesso, use o conector do Slack (`slack_send_message`) para enviar ao canal
+**#agility-creative** UMA mensagem curta com apenas:
+- **Tema/título** do artigo.
+- **Link** live: `https://www.agilitycreative.com/blog/<slug>`
+
+Nada mais (sem excerpt, sem fontes, sem token). Em caso de falha na publicação, avise no mesmo
+canal com uma linha sobre o erro (sem vazar o token).
+
+---
+
+## REGRAS DE OURO
+- **Nunca** invente fatos. Na dúvida, atribua à fonte ou omita.
+- **Nunca** copie trechos — sempre reescreva.
+- **Nunca** repita um tópico do `historico.json`.
+- **Nunca** faça o POST pelo bash/python (sem rede) — só pelo Chrome (Etapa 5). Nunca vaze o token.
+- **1 artigo por execução**. Se nada relevante e inédito surgir, escreva sobre o tema novo
+  mais forte do dia — mas nunca repita assunto.

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,83 @@
+# Blog Bot — Agility
+
+Bot autônomo que gera e publica **1 artigo de tecnologia em PT-BR por dia** no blog da Agility
+(`agilitycreative.com/blog`), consumindo a API existente do site.
+
+## Arquitetura (tudo no Cowork)
+
+O bash/python do ambiente do Cowork **não tem rede para a API** (firewall). A solução: a própria
+tarefa agendada publica **pelo Chrome** — o navegador roda no seu Mac, tem rede real, e como a
+página e a API estão na mesma origem (`https://www.agilitycreative.com`), o `fetch` interno não
+sofre CORS.
+
+```
+┌─ Tarefa agendada do Cowork (todo dia 6h) ──────────────────────────┐
+│  0. CHECA bot/queue/ primeiro:                                      │
+│     • tem pendente? → pula a pesquisa, só publica (economiza tokens)│
+│     • fila vazia?   → segue o fluxo completo abaixo                 │
+│  1. navega as fontes → cruza → escreve o artigo PT-BR              │
+│  2. grava o payload em bot/queue/<data>-<slug>.json                │
+│  3. PUBLICA via Chrome: navega em /blog e faz fetch('/api/blog')   │
+│     (POST de mesma origem, token lido de bot/.secret-token)        │
+│  4. em 201: move o arquivo p/ bot/published/ + historico.json      │
+│     (em falha: arquivo fica na fila e é reaproveitado amanhã)      │
+│  5. avisa no Slack #agility-creative (tema + link)                 │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+**Dependência:** o Google Chrome precisa estar **aberto com a extensão do Claude conectada** às 6h.
+
+## Arquivos
+
+| Arquivo | Função |
+|---|---|
+| `PROMPT-DIARIO.md` | Instruções da tarefa agendada (fonte de verdade do processo). |
+| `guia-de-voz.md` | Tom, público e estrutura editorial. |
+| `sources.json` | Fontes (homepages + pesos). |
+| `api.json` | Config e restrições da API. |
+| `historico.json` | `publicados` (dedup de temas) + `links_lidos` (dedup de leitura). |
+| `.secret-token` | Token da API. **Não commitar.** |
+| `queue/` | Artigos prontos aguardando publicação. Se um pendente sobra, a próxima execução só publica (sem pesquisar). |
+| `published/` `failed/` | Arquivos movidos após sucesso (201) / erro definitivo. |
+| `rascunhos/` | Dry run e material de apoio. |
+| `publish.mjs`, `run-publisher.sh`, `*.plist` | **Fallback opcional** (publicador local via launchd). Ver abaixo. Não usado no fluxo padrão (Chrome). |
+
+## Pré-requisitos (uma vez)
+
+1. **Chrome + extensão do Claude** conectada (para o passo de publicação).
+2. **Conector do Slack** ativo no Cowork, com acesso ao canal `#agility-creative`.
+3. **`bot/.secret-token`** com o token real (já configurado).
+4. Na seção *Scheduled* da barra lateral, clique **"Run now"** uma vez para pré-aprovar as
+   ferramentas (Chrome, Slack, arquivos) — assim os runs automáticos não param pedindo permissão.
+
+## Agendamento
+Tarefa **blog-agility-diario**, todo dia às 6h (horário local). Gerencie em *Scheduled*.
+Como tarefas do Cowork só rodam com o app aberto, se o Mac estiver desligado às 6h, roda no
+próximo abrir do app.
+
+## Fallback opcional: publicador local (launchd)
+Se algum dia você preferir publicar fora do Chrome (ex.: rodar headless), o publicador Node
+continua disponível: ele lê `bot/queue/*.json` e faz o POST no host.
+```bash
+cd ~/Desktop/_dev/Agility/agility-app/bot
+node publish.mjs --dry-run            # valida sem publicar
+cp ~/Desktop/_dev/Agility/agility-app/bot/com.agility.blog-publisher.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.agility.blog-publisher.plist
+```
+> Atenção: se ativar o launchd E o fluxo do Chrome ao mesmo tempo, há risco de publicação dupla.
+> Use um ou outro. No fluxo padrão (Chrome), **não** instale o launchd.
+
+## Segurança
+- `.secret-token` e `.slack-webhook` estão no `.gitignore`. O token nunca aparece em logs/Slack.
+
+## Decisões fechadas
+- Publicação: **a própria tarefa do Cowork, via Chrome** (sem launchd no fluxo padrão).
+- Modelo: **auto-publica**, avisa no `#agility-creative` só com tema + link.
+- Fontes: Tecnoblog, Olhar Digital, Zoom Digital, TechTudo, TechRadar (EN), Sydle (peso baixo).
+- Imagem de capa: placeholder por enquanto (placehold.co).
+
+## Pendências
+- [ ] Garantir Chrome aberto + extensão conectada às 6h (ou rodar via "Run now" quando estiver).
+- [ ] Confirmar que o conector do Slack alcança `#agility-creative`.
+- [ ] Categorias do blog hoje: **Gestão, Produto, Design**. Decidir se tech/IA entra como
+      categoria nova fixa (ex.: "Inteligência Artificial"/"Tecnologia").

--- a/bot/api.json
+++ b/bot/api.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "Config da API de publicacao. O TOKEN nao fica aqui em texto puro — ver nota de seguranca no plano.",
+  "endpoint": "https://agilitycreative.com/api/blog",
+  "method": "POST",
+  "content_type": "application/json",
+  "auth": {
+    "type": "bearer",
+    "header": "Authorization",
+    "value_format": "Bearer <BLOG_API_TOKEN>",
+    "token_storage": "PENDENTE — definir local seguro (nao commitar no repo)"
+  },
+  "actions": ["list", "read", "create", "update"],
+  "no_delete": true,
+  "no_drafts": true,
+  "create": {
+    "wrapper": { "action": "create", "post": "<BlogPostInput>" },
+    "required_fields": ["title", "excerpt", "body"],
+    "title_len": "3-200",
+    "excerpt_len": "10-500",
+    "body_format": "array de blocos tipados (NAO e markdown/html)",
+    "body_block_types": ["paragraph", "heading", "list", "quote", "image", "code"],
+    "optional_fields": ["slug", "coverImage", "coverAlt", "publishedAt", "updatedAt", "readingTimeMinutes", "category", "tags", "author"],
+    "coverImage": "deve ser URL absoluta ou /caminho — 1600x900 recomendado",
+    "category_rule": "reusar labels existentes EXATAMENTE (rodar 'list' antes para ver labels)",
+    "success": "201"
+  },
+  "workflow_pre_publish": [
+    "1. action=list para ver categorias existentes e titulos recentes (evitar overlap/slug_conflict)",
+    "2. action=create com o artigo"
+  ],
+  "constraints": {
+    "instant_live": "create retorna 201 e o post JA fica publicado em /blog/<slug> e no sitemap",
+    "no_unpublish_via_api": "nao ha delete; 'revogar' so via edicao manual de blog.json no servidor",
+    "slug_imutavel": "slug nao pode mudar apos criado (SEO)",
+    "single_writer": "serializar chamadas — sem lock de concorrencia"
+  }
+}

--- a/bot/com.agility.blog-publisher.plist
+++ b/bot/com.agility.blog-publisher.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agility.blog-publisher</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/renan/Desktop/_dev/Agility/agility-app/bot/run-publisher.sh</string>
+  </array>
+
+  <!-- Roda a cada 15 minutos. O script é idempotente: se a fila estiver vazia, sai na hora.
+       Assim não importa quanto tempo o Cowork leva para escrever o artigo às 6h. -->
+  <key>StartInterval</key>
+  <integer>900</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/renan/Desktop/_dev/Agility/agility-app/bot/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/renan/Desktop/_dev/Agility/agility-app/bot/launchd.err.log</string>
+</dict>
+</plist>

--- a/bot/guia-de-voz.md
+++ b/bot/guia-de-voz.md
@@ -1,0 +1,36 @@
+# Guia de voz — Blog Agility
+
+## Quem somos
+Startup de tecnologia formada por jovens criativos. Desenvolvemos desde sites simples,
+landing pages e sites corporativos até aplicativos complexos, além de consultoria de tecnologia.
+
+## Objetivo do blog
+Divulgar conteúdo interessante tanto para o **público geral** quanto para o **público
+especializado em tecnologia**. Foco forte em **inteligência artificial**, novidades do setor,
+e principalmente a **aplicação prática no dia a dia** — não apenas teoria ou termos técnicos.
+
+## Tom de voz
+- **Linguagem simples e acessível.** Traduzir/explicar termos técnicos quando necessário.
+- **Meio-termo:** nem totalmente descontraído, nem muito formal. Profissional, mas humano.
+- Sempre que usar um termo complexo, explicar em poucas palavras o que significa.
+- Conectar a novidade à vida real do leitor ("o que isso muda pra você").
+
+## Faça
+- Explicar siglas e jargões na primeira vez que aparecem.
+- Usar exemplos concretos e analogias do cotidiano.
+- Equilibrar profundidade (pro público técnico) com clareza (pro público geral).
+- Texto original — sintetizar as fontes com palavras próprias e citar/linkar a origem.
+
+## Evite
+- Copiar trechos das fontes.
+- Excesso de jargão sem explicação.
+- Tom de marketing agressivo ou clickbait.
+- Formalidade acadêmica ou descontração exagerada (gírias demais).
+
+## Estrutura padrão do artigo
+1. Título claro e atraente (sem clickbait).
+2. Lede: 1 parágrafo de abertura que situa o tema.
+3. Corpo com subtítulos (h2/h3), explicando o tema e sua aplicação prática.
+4. Quando útil: listas, citações, exemplos.
+5. Fechamento que conecta o tema ao leitor.
+6. Fontes citadas/linkadas.

--- a/bot/historico.json
+++ b/bot/historico.json
@@ -1,0 +1,21 @@
+{
+  "publicados": [],
+  "links_lidos": [
+    "https://news.microsoft.com/source/emea/features/microsoft-build-2026-reforca-nova-era-da-ia-com-agentes-inteligentes-plataformas-abertas-e-avancos-em-computacao-quantica/",
+    "https://news.microsoft.com/build-2026-live-blog",
+    "https://news.microsoft.com/build-2026/",
+    "https://www.showmetech.com.br/microsoft-build-2026-anuncios-ia-agentes-surface-rtx-spark/",
+    "https://tek.sapo.pt/noticias/computadores/artigos/microsoft-build-2026-sete-novos-modelos-mai-agentes-que-conhecem-as-empresas-e-chip-quantico-majorana-2/",
+    "https://www.ocafezinho.com/2026/06/02/microsoft-apresenta-avancos-em-ia-agentes-autonomos-e-chip-quantico-no-build-2026/",
+    "https://canaltech.com.br/inteligencia-artificial/7-novidades-de-ia-anunciadas-na-ces-2026/",
+    "https://www.publico.pt/2026/06/03/enter/noticia/microsoft-anuncia-novos-trabalhadores-virtuais-baseados-ia-salto-quantico-2177023",
+    "https://www.enter.co/especiales/dev/inteligencia-artificial/microsoft-build-2026-agentes-ia-modelos-seguridad/",
+    "https://raona.com/microsoft-build-novedades/",
+    "https://isenacode.com/microsoft-build-2026/",
+    "https://wwwhatsnew.com/2026/06/03/microsoft-build-2026-agent-framework-polaris-windows-local-ai-solara/",
+    "https://www.techtudo.com.br/noticias/2026/01/novidades-sobre-inteligencia-artificial-o-que-esperar-da-tecnologia-em-2026-edsoftwares.ghtml",
+    "https://www.startse.com/artigos/qual-modelo-de-ia-mais-inteligente-para-usar-em-26/",
+    "https://www.teamlewis.com/pt/magazine/8-tendencias-de-inteligencia-artificial-2026/",
+    "https://scansource.com.br/blog/tendencias-inteligencia-artificial-2026/"
+  ]
+}

--- a/bot/publish.mjs
+++ b/bot/publish.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Publicador local do Blog Agility.
+ *
+ * Roda no SEU Mac (via launchd), fora do sandbox do Cowork — por isso tem rede
+ * real para chamar a API. Fluxo:
+ *   1. Lê todos os artigos prontos em bot/queue/*.json
+ *   2. Faz POST na API (action=create) com o token de bot/.secret-token
+ *   3. Em sucesso: registra em historico.json (publicados), move o arquivo para
+ *      bot/published/ e (se houver webhook) avisa no Slack #agility-creative
+ *   4. Em falha: move para bot/failed/ e loga o motivo
+ *
+ * Uso:
+ *   node publish.mjs            # publica de verdade
+ *   node publish.mjs --dry-run  # valida tudo SEM chamar a API nem mover arquivos
+ *
+ * Idempotente: se a fila estiver vazia, não faz nada. Pode rodar a cada X minutos.
+ */
+
+import { readFile, writeFile, readdir, mkdir, rename } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DRY = process.argv.includes('--dry-run');
+const HERE = path.dirname(fileURLToPath(import.meta.url));      // .../agility-app/bot
+const QUEUE = path.join(HERE, 'queue');
+const PUBLISHED = path.join(HERE, 'published');
+const FAILED = path.join(HERE, 'failed');
+const HISTORICO = path.join(HERE, 'historico.json');
+const TOKEN_FILE = path.join(HERE, '.secret-token');
+const WEBHOOK_FILE = path.join(HERE, '.slack-webhook');        // opcional
+const API = 'https://www.agilitycreative.com/api/blog';
+const SITE_BASE = 'https://www.agilitycreative.com/blog';
+
+const log = (...a) => console.log(new Date().toISOString(), ...a);
+
+async function readJson(file, fallback) {
+  try { return JSON.parse(await readFile(file, 'utf8')); }
+  catch (e) { if (fallback !== undefined) return fallback; throw e; }
+}
+
+// Monta o payload aceito pela API a partir do arquivo da fila.
+// Remove chaves auxiliares (começam com "_") e garante { action: 'create', post }.
+function buildPayload(raw) {
+  const clean = {};
+  for (const [k, v] of Object.entries(raw)) if (!k.startsWith('_')) clean[k] = v;
+  if (clean.post) return { action: 'create', post: clean.post };
+  if (clean.action === 'create' && clean.post) return clean;
+  // arquivo é o próprio "post" cru
+  return { action: 'create', post: clean };
+}
+
+async function notifySlack(webhook, tema, url) {
+  if (!webhook) { log('Slack: sem webhook configurado, pulando aviso.'); return; }
+  const text = `📝 Novo artigo publicado no blog:\n*${tema}*\n${url}`;
+  if (DRY) { log('[dry-run] Slack ->', text.replace(/\n/g, ' | ')); return; }
+  try {
+    const r = await fetch(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+    log('Slack:', r.status);
+  } catch (e) { log('Slack ERRO:', e.message); }
+}
+
+async function main() {
+  if (!existsSync(QUEUE)) { log('Sem pasta queue/. Nada a fazer.'); return; }
+
+  const files = (await readdir(QUEUE)).filter(f => f.endsWith('.json')).sort();
+  if (files.length === 0) { log('Fila vazia. Nada a publicar.'); return; }
+
+  const token = (await readFile(TOKEN_FILE, 'utf8')).replace(/[\n\r]/g, '').trim();
+  if (!token) { log('ERRO: token vazio em .secret-token. Abortando.'); process.exit(1); }
+  const webhook = existsSync(WEBHOOK_FILE)
+    ? (await readFile(WEBHOOK_FILE, 'utf8')).trim() : null;
+
+  if (!DRY) { await mkdir(PUBLISHED, { recursive: true }); await mkdir(FAILED, { recursive: true }); }
+
+  const historico = await readJson(HISTORICO, { publicados: [], links_lidos: [] });
+  if (!Array.isArray(historico.publicados)) historico.publicados = [];
+
+  for (const f of files) {
+    const src = path.join(QUEUE, f);
+    let payload;
+    try { payload = buildPayload(await readJson(src)); }
+    catch (e) { log(`PARSE FALHOU ${f}: ${e.message}`); if (!DRY) await rename(src, path.join(FAILED, f)); continue; }
+
+    const tema = payload.post?.title || '(sem título)';
+    log(`Processando ${f} -> "${tema}"`);
+
+    if (DRY) {
+      log(`  [dry-run] POST ${API} | campos: ${Object.keys(payload.post || {}).join(', ')}`);
+      log(`  [dry-run] body blocks: ${Array.isArray(payload.post?.body) ? payload.post.body.length : 'AUSENTE!'}`);
+      continue;
+    }
+
+    let res, json;
+    try {
+      res = await fetch(API, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        redirect: 'follow',
+      });
+      json = await res.json().catch(() => ({}));
+    } catch (e) {
+      log(`  REDE FALHOU: ${e.message}. Mantendo na fila para retry.`);
+      continue; // não move: tenta de novo no próximo ciclo
+    }
+
+    if (res.status === 201 && json.ok) {
+      const slug = json.data?.post?.slug || payload.post?.slug;
+      const url = `${SITE_BASE}/${slug}`;
+      historico.publicados.unshift({
+        data: new Date().toISOString().slice(0, 10),
+        tema, slug, categoria: payload.post?.category || null,
+      });
+      await writeFile(HISTORICO, JSON.stringify(historico, null, 2) + '\n');
+      await rename(src, path.join(PUBLISHED, f));
+      log(`  OK 201 -> ${url}`);
+      await notifySlack(webhook, tema, url);
+    } else if (res.status === 409) {
+      log(`  409 slug_conflict (já existe). Movendo para failed/.`);
+      await rename(src, path.join(FAILED, f));
+    } else {
+      log(`  ERRO ${res.status} ${json.error || ''} ${JSON.stringify(json.details || {})}`);
+      await rename(src, path.join(FAILED, f));
+    }
+  }
+  log('Concluído.');
+}
+
+main().catch(e => { console.error('FATAL', e); process.exit(1); });

--- a/bot/run-publisher.sh
+++ b/bot/run-publisher.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Wrapper chamado pelo launchd. Localiza o node e roda o publicador.
+cd "$(dirname "$0")" || exit 1
+
+# Garantir que o node seja encontrado mesmo no PATH minimo do launchd
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+if [ -s "$HOME/.nvm/nvm.sh" ]; then . "$HOME/.nvm/nvm.sh" >/dev/null 2>&1; fi
+
+NODE="$(command -v node)"
+if [ -z "$NODE" ]; then
+  echo "$(date '+%Y-%m-%dT%H:%M:%S') ERRO: node nao encontrado no PATH" >> publish.log
+  exit 1
+fi
+
+"$NODE" publish.mjs >> publish.log 2>&1

--- a/bot/sources.json
+++ b/bot/sources.json
@@ -1,0 +1,65 @@
+{
+  "_comment": "Rascunho (Fase 0). Fontes de tópicos para o bot diário. 'weight' = prioridade relativa na seleção de tópicos.",
+  "language": "pt-BR",
+  "lookback_hours": 72,
+  "sources": [
+    {
+      "name": "Tecnoblog",
+      "url": "https://tecnoblog.net/",
+      "feed": "https://tecnoblog.net/feed/",
+      "type": "rss",
+      "category": "tech-consumo",
+      "weight": 1.0,
+      "status": "ok"
+    },
+    {
+      "name": "Olhar Digital",
+      "url": "https://olhardigital.com.br/",
+      "feed": "https://olhardigital.com.br/feed/",
+      "type": "rss",
+      "category": "tech-consumo",
+      "weight": 1.0,
+      "status": "ok"
+    },
+    {
+      "name": "Zoom Digital",
+      "url": "https://zoomdigital.com.br/",
+      "feed": "https://zoomdigital.com.br/feed/",
+      "type": "rss",
+      "category": "tech-consumo",
+      "weight": 0.8,
+      "status": "ok"
+    },
+    {
+      "name": "TechTudo",
+      "url": "https://www.techtudo.com.br/",
+      "feed": null,
+      "type": "web-fallback",
+      "category": "tech-consumo",
+      "weight": 0.7,
+      "status": "no-rss",
+      "note": "Sem RSS público. Coletar via busca web / leitura da página renderizada. Fonte menos estável."
+    },
+    {
+      "name": "TechRadar",
+      "url": "https://www.techradar.com/",
+      "feed": "https://www.techradar.com/feeds.xml",
+      "type": "rss",
+      "category": "tech-internacional",
+      "weight": 0.7,
+      "status": "ok",
+      "lang": "en",
+      "note": "Fonte em INGLES. Usar como fonte de topicos, mas escrever o artigo em PT-BR (traduzir/adaptar, nunca copiar). Bom para novidades globais antes de chegarem ao Brasil."
+    },
+    {
+      "name": "Blog SYDLE",
+      "url": "https://www.sydle.com/br/blog",
+      "feed": "https://www.sydle.com/br/blog/feed",
+      "type": "rss",
+      "category": "transformacao-digital-corporativa",
+      "weight": 0.4,
+      "status": "ok",
+      "note": "Perfil editorial diferente (BPM/CRM/fintech). Confirmar com o usuario se entra como fonte de topicos."
+    }
+  ]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,9 @@ export default antfu({
   ignores: [
     'migrations/**/*',
     'next-env.d.ts',
+    // Standalone Node bot runtime — runs under launchd outside the Next.js
+    // build pipeline. Has its own conventions (console logging, etc.).
+    'bot/**/*',
   ],
 }, ...tailwind.configs['flat/recommended'], jsxA11y.flatConfigs.recommended, {
   plugins: {

--- a/migrations/0001_handy_vampiro.sql
+++ b/migrations/0001_handy_vampiro.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "blog_store" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"data" jsonb NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "guestbook" ADD PRIMARY KEY ("id");

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,97 @@
+{
+  "id": "d88be45f-3ec4-4caf-83b9-33c4a35015f1",
+  "prevId": "476c2d87-fe0f-47d2-9386-42280f661547",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_store": {
+      "name": "blog_store",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guestbook": {
+      "name": "guestbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1719279419936,
       "tag": "0000_init_db",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1780691119589,
+      "tag": "0001_handy_vampiro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,25 +1,22 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
+import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 
 import { BlogArticleBody, BlogHero } from '@/components/blog';
-import blogData from '@/data/blog.json';
+import { getPostsSafe } from '@/libs/blogStore';
 import { Link } from '@/libs/i18nNavigation';
-import type { BlogPost } from '@/types/blog';
+import { isPublished } from '@/types/blog';
 import { AppConfig } from '@/utils/AppConfig';
 import { getBaseUrl } from '@/utils/Helpers';
 import { buildAlternates, localizedUrl, ogAlternateLocales, ogLocale } from '@/utils/seo';
+
+export const dynamic = 'force-dynamic';
 
 type Params = {
   slug: string;
   locale: string;
 };
-
-const posts = blogData as BlogPost[];
-
-export async function generateStaticParams() {
-  return posts.map(post => ({ slug: post.slug }));
-}
 
 export async function generateMetadata(props: {
   params: Promise<Params>;
@@ -28,6 +25,7 @@ export async function generateMetadata(props: {
   const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
     ? (locale as (typeof AppConfig.locales)[number])
     : AppConfig.defaultLocale;
+  const posts = await getPostsSafe();
   const post = posts.find(item => item.slug === slug);
   const alternates = buildAlternates(safeLocale, `/blog/${slug}`);
   const title = post?.title ?? slug;
@@ -70,15 +68,15 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
     ? (locale as (typeof AppConfig.locales)[number])
     : AppConfig.defaultLocale;
   const t = await getTranslations('BlogDetail');
-  const post = posts.find(item => item.slug === slug);
-
-  if (!post) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <p className="text-base text-neutral-500">{t('notFound')}</p>
-      </div>
-    );
+  const posts = await getPostsSafe();
+  const existing = posts.find(item => item.slug === slug);
+  // Real 404 (not a soft 200 with a "not found" message) for both missing
+  // slugs and drafts — keeps unpublished URLs out of search indexes and
+  // matches the category page's behavior.
+  if (!existing || !isPublished(existing)) {
+    notFound();
   }
+  const post = existing;
 
   const dateLabel = new Intl.DateTimeFormat(safeLocale === 'pt-BR' ? 'pt-BR' : 'en-US', {
     year: 'numeric',
@@ -106,24 +104,24 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
   const heroMeta = (
     <>
       {post.author?.avatar && (
-        <span className="relative inline-flex size-7 overflow-hidden rounded-full border border-neutral-200 bg-neutral-50">
+        <span className="relative inline-flex size-8 overflow-hidden rounded-full border border-stone-200/70 bg-stone-100">
           <Image
             src={post.author.avatar}
             alt={post.author.name}
             fill
-            sizes="28px"
+            sizes="32px"
             className="object-contain p-1.5"
           />
         </span>
       )}
       {post.author && (
-        <span className="font-medium text-neutral-700">{post.author.name}</span>
+        <span className="font-medium text-stone-700">{post.author.name}</span>
       )}
-      <span aria-hidden className="text-neutral-300">·</span>
+      <span aria-hidden className="size-1 rounded-full bg-stone-300" />
       <time dateTime={post.publishedAt}>{dateLabel}</time>
       {post.readingTimeMinutes && (
         <>
-          <span aria-hidden className="text-neutral-300">·</span>
+          <span aria-hidden className="size-1 rounded-full bg-stone-300" />
           <span>
             {post.readingTimeMinutes}
             {' '}
@@ -147,15 +145,15 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
         ]}
       />
 
-      <article className="mx-auto max-w-[680px] px-4 py-16 sm:px-6 md:py-20">
+      <article className="mx-auto max-w-[720px] px-5 py-20 sm:px-8 md:py-28">
         {post.coverImage && (
-          <figure className="mb-12 overflow-hidden rounded-xl border border-neutral-200">
+          <figure className="mb-16 overflow-hidden rounded-2xl ring-1 ring-stone-200/70">
             <Image
               src={post.coverImage}
               alt={post.coverAlt ?? post.title}
               width={1600}
               height={900}
-              sizes="(max-width: 768px) 100vw, 680px"
+              sizes="(max-width: 768px) 100vw, 720px"
               priority
               className="h-auto w-full"
             />
@@ -165,26 +163,24 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
         <BlogArticleBody blocks={post.body} />
 
         {post.tags && post.tags.length > 0 && (
-          <div className="mt-16 flex flex-wrap gap-2 border-t border-neutral-200 pt-8">
+          <div className="mt-20 flex flex-wrap gap-2 border-t border-stone-200/70 pt-10">
             {post.tags.map(tag => (
               <span
                 key={tag}
-                className="rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1 text-xs text-neutral-500"
+                className="rounded-full border border-stone-200/70 bg-white px-3 py-1 text-[11px] font-medium uppercase tracking-[0.12em] text-stone-500"
               >
-                #
                 {tag}
               </span>
             ))}
           </div>
         )}
 
-        <div className="mt-12 border-t border-neutral-200 pt-8">
+        <div className="mt-14 border-t border-stone-200/70 pt-10">
           <Link
             href="/blog"
-            className="inline-flex items-center gap-2 text-sm font-medium text-neutral-600 transition-colors hover:text-neutral-900"
+            className="group inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-500 transition-colors hover:text-stone-900"
           >
-            <span aria-hidden>←</span>
-            {' '}
+            <span aria-hidden className="transition-transform group-hover:-translate-x-0.5">←</span>
             {t('backToBlog')}
           </Link>
         </div>

--- a/src/app/[locale]/blog/category/[slug]/page.tsx
+++ b/src/app/[locale]/blog/category/[slug]/page.tsx
@@ -7,26 +7,21 @@ import {
   BlogHero,
   BlogIndex,
   findCategoryBySlug,
-  getAllCategorySlugs,
   getOrderedCategories,
   slugifyCategory,
 } from '@/components/blog';
-import blogData from '@/data/blog.json';
-import type { BlogPost } from '@/types/blog';
+import { getPostsSafe } from '@/libs/blogStore';
+import { isPublished } from '@/types/blog';
 import { AppConfig } from '@/utils/AppConfig';
 import { getBaseUrl } from '@/utils/Helpers';
 import { buildAlternates, localizedUrl, ogAlternateLocales, ogLocale } from '@/utils/seo';
+
+export const dynamic = 'force-dynamic';
 
 type Params = {
   slug: string;
   locale: string;
 };
-
-const posts = blogData as BlogPost[];
-
-export function generateStaticParams() {
-  return getAllCategorySlugs(posts).map(slug => ({ slug }));
-}
 
 export async function generateMetadata(props: {
   params: Promise<Params>;
@@ -35,6 +30,7 @@ export async function generateMetadata(props: {
   const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
     ? (locale as (typeof AppConfig.locales)[number])
     : AppConfig.defaultLocale;
+  const posts = await getPostsSafe();
   const category = findCategoryBySlug(posts, slug);
   const t = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
   const alternates = buildAlternates(safeLocale, `/blog/category/${slug}`);
@@ -79,6 +75,7 @@ const BlogCategoryPage = async (props: { params: Promise<Params> }) => {
   const safeLocale = (AppConfig.locales as readonly string[]).includes(locale)
     ? (locale as (typeof AppConfig.locales)[number])
     : AppConfig.defaultLocale;
+  const posts = await getPostsSafe();
   const category = findCategoryBySlug(posts, slug);
 
   if (!category) {
@@ -88,8 +85,12 @@ const BlogCategoryPage = async (props: { params: Promise<Params> }) => {
   const tBlog = await getTranslations('BlogPage');
   const tCategory = await getTranslations('BlogCategory');
 
-  const sortedPosts = [...posts]
-    .filter(post => post.category && slugifyCategory(post.category) === slug)
+  const sortedPosts = posts
+    .filter(post =>
+      isPublished(post)
+      && post.category
+      && slugifyCategory(post.category) === slug,
+    )
     .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
 
   const items: BlogCardItem[] = sortedPosts.map(post => ({
@@ -103,7 +104,7 @@ const BlogCategoryPage = async (props: { params: Promise<Params> }) => {
     readingTimeMinutes: post.readingTimeMinutes,
   }));
 
-  const categories = getOrderedCategories(posts);
+  const categories = getOrderedCategories(posts.filter(isPublished));
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -149,6 +150,7 @@ const BlogCategoryPage = async (props: { params: Promise<Params> }) => {
         allLabel={tBlog('allLabel')}
         readArticleLabel={tBlog('readArticle')}
         emptyLabel={tBlog('empty')}
+        moreLabel={tBlog('more')}
       />
 
       <script

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -3,15 +3,15 @@ import { getTranslations } from 'next-intl/server';
 
 import type { BlogCardItem } from '@/components/blog';
 import { BlogHero, BlogIndex, getOrderedCategories } from '@/components/blog';
-import blogData from '@/data/blog.json';
-import type { BlogPost } from '@/types/blog';
+import { getPostsSafe } from '@/libs/blogStore';
+import { isPublished } from '@/types/blog';
 import { AppConfig } from '@/utils/AppConfig';
 import { getBaseUrl } from '@/utils/Helpers';
 import { buildAlternates, localizedUrl, ogAlternateLocales, ogLocale } from '@/utils/seo';
 
-const BLOG_PATH = '/blog';
+export const dynamic = 'force-dynamic';
 
-const posts = blogData as BlogPost[];
+const BLOG_PATH = '/blog';
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
@@ -54,9 +54,10 @@ const BlogPage = async (props: { params: Promise<{ locale: string }> }) => {
     : AppConfig.defaultLocale;
   const t = await getTranslations('BlogPage');
 
-  const sortedPosts = [...posts].sort(
-    (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
-  );
+  const posts = await getPostsSafe();
+  const sortedPosts = posts
+    .filter(isPublished)
+    .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
 
   const items: BlogCardItem[] = sortedPosts.map(post => ({
     slug: post.slug,
@@ -109,6 +110,7 @@ const BlogPage = async (props: { params: Promise<{ locale: string }> }) => {
         allLabel={t('allLabel')}
         readArticleLabel={t('readArticle')}
         emptyLabel={t('empty')}
+        moreLabel={t('more')}
       />
 
       <script

--- a/src/app/api/blog/auth.ts
+++ b/src/app/api/blog/auth.ts
@@ -1,0 +1,28 @@
+import { Buffer } from 'node:buffer';
+import crypto from 'node:crypto';
+
+// Reusable bearer-token check for every blog API route. The token is the
+// 32-char MD5 hex stored in BLOG_API_TOKEN. Constant-time comparison.
+export const isAuthorized = (req: Request): boolean => {
+  const expected = process.env.BLOG_API_TOKEN;
+  if (!expected) {
+    return false;
+  }
+  const header = req.headers.get('authorization') ?? '';
+  // Anchored single-space separator avoids super-linear backtracking on \s+(.+).
+  const match = /^Bearer (\S.*)$/i.exec(header);
+  if (!match || !match[1]) {
+    return false;
+  }
+  const provided = match[1].trim();
+  const expectedBuf = Buffer.from(expected);
+  const providedBuf = Buffer.from(provided);
+  if (expectedBuf.length !== providedBuf.length) {
+    return false;
+  }
+  try {
+    return crypto.timingSafeEqual(expectedBuf, providedBuf);
+  } catch {
+    return false;
+  }
+};

--- a/src/app/api/blog/context.md
+++ b/src/app/api/blog/context.md
@@ -1,12 +1,18 @@
 # Agility Blog API — agent reference
 
-A single authenticated HTTP endpoint that lets AI agents manage blog articles published on `agilitycreative.com/blog`. Every operation goes through one POST request whose `action` field picks the verb.
+Two authenticated HTTP endpoints that let AI agents manage blog articles published on `agilitycreative.com/blog`:
 
-- **Endpoint**: `POST /api/blog`
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /api/blog`        | CRUD on posts — `list`, `read`, `create`, `update`, `publish`, `unpublish`, `delete` |
+| `POST /api/blog/upload` | Upload an image and get back a public URL you can drop into `coverImage` or body `image` blocks |
+
 - **Content-Type**: `application/json`
-- **Auth**: `Authorization: Bearer <BLOG_API_TOKEN>` (32-char MD5 hex)
-- **Runtime**: Node.js (the route writes to the local filesystem — do not deploy to a read-only serverless runtime without swapping the storage layer)
-- **Storage**: `src/data/blog.json` — flat JSON array, newest first. Reads and writes are atomic (`write → rename`), but there is **no concurrent-write locking**. Treat the API as single-writer.
+- **Auth (both routes)**: `Authorization: Bearer <BLOG_API_TOKEN>` (32-char MD5 hex)
+- **Runtime**: Node.js
+- **Storage**:
+  - Posts: **Postgres via Drizzle** (`src/libs/blogStore.ts`, one JSONB row in `blog_store`). Seeded from `src/data/blog.json` on the first read; that JSON also serves as a graceful fallback if the DB is unreachable.
+  - Images: `public/blog/uploads/<sha256-16>.<ext>` — content-addressed, served from `/blog/uploads/`. Idempotent: uploading the same bytes twice yields the same URL and short-circuits the write. ⚠️ Still filesystem-backed — won't persist on serverless. Migrate to Blob/S3/R2 before relying on uploads in prod.
 
 ---
 
@@ -49,32 +55,58 @@ type Err = { ok: false; error: string; details?: unknown };
 
 | HTTP | When it happens |
 |------|-----------------|
-| 200  | `list`, `read`, `update` success |
-| 201  | `create` success |
-| 400  | `invalid_json` (body wasn't JSON) or `invalid_request` (zod validation failed — see `details.fieldErrors`) |
+| 200  | `list`, `read`, `update`, `publish`, `unpublish`, `delete`, image already exists |
+| 201  | `create` and new image upload |
+| 400  | `invalid_json` (body wasn't JSON), `invalid_request` (zod validation — see `details.fieldErrors`), `invalid_slug`, `invalid_base64` |
 | 401  | Missing/wrong bearer token |
-| 404  | `not_found` (read/update with unknown slug) |
-| 409  | `slug_conflict` on create (a post with the same slug already exists) |
-| 500  | `storage_read_failed` / `storage_write_failed` — the JSON file couldn't be read/written |
+| 404  | `not_found` (read/update/publish/unpublish/delete with unknown slug) |
+| 409  | `slug_conflict` on create |
+| 413  | `payload_too_large` (image > 5 MB after decode) |
+| 500  | `storage_read_failed` / `storage_write_failed` |
 
 ---
 
-## 3. Actions
+## 3. Draft & publish lifecycle
+
+Every post has a `status` of either `'draft'` or `'published'` (legacy posts without the field are treated as `'published'`).
+
+| Surface                                | Draft visible? |
+|----------------------------------------|----------------|
+| `/blog` listing page                   | no             |
+| `/blog/[slug]` detail page             | no — returns 404 |
+| `/blog/category/[slug]` page           | no             |
+| Sitemap (`/sitemap.xml`)               | no             |
+| `generateStaticParams`                 | no (no pre-render) |
+| `POST /api/blog list` default          | no             |
+| `POST /api/blog list` with `includeDrafts: true` | yes  |
+| `POST /api/blog list` with `status: 'draft'` | only drafts |
+| `POST /api/blog read`                  | yes (so the agent can fetch the draft to edit) |
+
+Three ways to flip a post's status:
+- `create` accepts `status: 'draft' | 'published'` (defaults to `'published'` — opt-in to drafts).
+- `update` accepts `status` in the patch.
+- Dedicated `publish` / `unpublish` actions take just `{ action, slug }` — convenient when you don't want to think about the patch shape. They're idempotent (`changed: false` if status already matches).
+
+---
+
+## 4. Actions on `POST /api/blog`
 
 The request body is always `{ "action": "...", ...payload }`. The `action` field discriminates which payload is expected.
 
-### 3.1 `list` — paginate posts
+### 4.1 `list` — paginate posts
 
 Returns a paginated, newest-first summary list. Bodies are **not** included to keep responses small.
 
 **Request fields**
 
-| Field          | Type                  | Notes |
-|----------------|-----------------------|-------|
-| `categorySlug` | `string?`             | Filter by category slug (e.g. `inteligencia-artificial`). Slugs come from `slugifyCategory(category)`. |
-| `category`     | `string?`             | Filter by exact category label (e.g. `"Inteligência Artificial"`). Ignored if `categorySlug` is set. |
-| `limit`        | `number?` (1–100)     | Default = all matching posts. |
-| `offset`       | `number?` (≥0)        | Default = 0. |
+| Field           | Type                  | Notes |
+|-----------------|-----------------------|-------|
+| `status`        | `'draft' \| 'published'?` | Filter by status. Omit → only `published`. |
+| `includeDrafts` | `boolean?`            | When `true`, returns both drafts and published. Ignored if `status` is set. |
+| `categorySlug`  | `string?`             | Filter by category slug (e.g. `inteligencia-artificial`). |
+| `category`      | `string?`             | Filter by exact category label (e.g. `"Inteligência Artificial"`). Ignored if `categorySlug` is set. |
+| `limit`         | `number?` (1–100)     | Default = all matching posts. |
+| `offset`        | `number?` (≥0)        | Default = 0. |
 
 **Response data**
 
@@ -89,6 +121,7 @@ Returns a paginated, newest-first summary list. Bodies are **not** included to k
     title: string;
     excerpt: string;
     category?: string;
+    status: 'draft' | 'published'; // always present, even on legacy posts
     publishedAt: string; // YYYY-MM-DD
     updatedAt?: string;
     readingTimeMinutes?: number;
@@ -97,45 +130,45 @@ Returns a paginated, newest-first summary list. Bodies are **not** included to k
 }
 ```
 
-**Example**
+**Examples**
 
 ```bash
+# Newest 10 published AI posts
 curl -s -X POST https://agilitycreative.com/api/blog \
   -H "Authorization: Bearer $BLOG_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"action":"list","categorySlug":"inteligencia-artificial","limit":10}'
+
+# Just my drafts
+curl -s -X POST https://agilitycreative.com/api/blog \
+  -H "Authorization: Bearer $BLOG_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"list","status":"draft"}'
 ```
 
 ---
 
-### 3.2 `read` — fetch one post (full body)
+### 4.2 `read` — fetch one post (full body)
+
+Returns drafts too. Use this to load a draft into your editor before sending an `update`.
 
 **Request fields**
 
 | Field  | Type     | Notes |
 |--------|----------|-------|
-| `slug` | `string` | Required. Matches the regex `^[a-z0-9]+(?:-[a-z0-9]+)*$`. |
+| `slug` | `string` | Required. Matches `^[a-z0-9]+(?:-[a-z0-9]+)*$`. |
 
 **Response data**
 
 ```ts
-{ post: BlogPost; } // full post including the body block array
+{ post: BlogPost; } // full post including `status` and the body block array
 ```
 
 **Errors**: `404 not_found` if no post matches.
 
-**Example**
-
-```bash
-curl -s -X POST https://agilitycreative.com/api/blog \
-  -H "Authorization: Bearer $BLOG_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"action":"read","slug":"mvp-em-30-dias-o-que-cabe-e-o-que-nao-cabe"}'
-```
-
 ---
 
-### 3.3 `create` — publish a new article
+### 4.3 `create` — author a new article
 
 **Request fields**
 
@@ -152,29 +185,28 @@ curl -s -X POST https://agilitycreative.com/api/blog \
 |----------------------|---------------------------------------------|----------|-------|
 | `slug`               | `string` `(^[a-z0-9]+(?:-[a-z0-9]+)*$)`     | ❌       | Auto-derived from `title` if omitted. Must be globally unique — 409 otherwise. |
 | `title`              | `string` (3–200)                            | ✅       | |
-| `excerpt`            | `string` (10–500)                           | ✅       | Shown in the card grid + meta description + OG description. Write it as standalone marketing copy. |
-| `coverImage`         | `string` (absolute URL or `/…` path)        | ❌       | 1600×900 recommended for the featured-card hero. |
-| `coverAlt`           | `string`                                    | ❌       | Image alt — required for accessibility if `coverImage` is set in a real post. |
+| `excerpt`            | `string` (10–500)                           | ✅       | Used in cards + meta description + OG description. Standalone marketing copy. |
+| `coverImage`         | `string` (absolute URL or `/…` path)        | ❌       | 1600×900 recommended. Upload via `POST /api/blog/upload` and paste the returned URL. |
+| `coverAlt`           | `string`                                    | ❌       | Image alt — recommended whenever `coverImage` is set. |
 | `publishedAt`        | `YYYY-MM-DD` or ISO 8601                    | ❌       | Defaults to today (UTC). |
 | `updatedAt`          | `YYYY-MM-DD` or ISO 8601                    | ❌       | |
 | `readingTimeMinutes` | `number` (1–120)                            | ❌       | Auto-computed from `body` (~200 wpm) if omitted. |
-| `category`           | `string` (1–60)                             | ❌       | Free-form label. The slug used in `/blog/category/<slug>` URLs is derived automatically via `slugifyCategory()`. Reuse existing labels exactly to land posts under the same tab. |
+| `category`           | `string` (1–60)                             | ❌       | Free-form label. Reuse existing labels exactly — slug auto-derived for `/blog/category/<slug>`. |
 | `tags`               | `string[]` (max 20, each 1–40 chars)        | ❌       | Plain words — no `#`. |
-| `author`             | `{ name, role?, avatar? }`                  | ❌       | `avatar` can be an absolute URL or `/…` path. |
-| `body`               | `BlogBodyBlock[]` (min 1)                   | ✅       | See §4. |
+| `author`             | `{ name, role?, avatar? }`                  | ❌       | `avatar` accepts absolute URL or `/…` path. |
+| `status`             | `'draft' \| 'published'`                    | ❌       | **Defaults to `'published'`** for backward compatibility. Send `'draft'` to stage without going live. |
+| `body`               | `BlogBodyBlock[]` (min 1)                   | ✅       | See §6. |
 
-**Response**: `201 Created` with the canonical stored post (slug, defaults, computed reading time) under `data.post`.
+**Response**: `201 Created` with the canonical stored post under `data.post`.
 
 **Errors**:
-- `400 invalid_request` — zod validation failures, `details.fieldErrors` says what's wrong per field.
+- `400 invalid_request` — zod validation issues, `details.fieldErrors` per field.
 - `400 invalid_slug` — title slugified to empty (e.g. emoji-only title).
 - `409 slug_conflict` — a post with that slug already exists. Use `update` instead.
 
 ---
 
-### 3.4 `update` — edit an existing article
-
-**Request fields**
+### 4.4 `update` — edit an existing article
 
 ```ts
 {
@@ -184,12 +216,12 @@ curl -s -X POST https://agilitycreative.com/api/blog \
 }
 ```
 
-Notes:
+Rules:
 
-- **`slug` inside `patch` is rejected** — slugs are URLs and must stay stable for SEO.
-- `updatedAt` is **always** overwritten with today's date, even if the caller sets it.
-- If `body` is included in the patch, `readingTimeMinutes` is recomputed unless explicitly provided.
-- Fields not present in `patch` are left untouched.
+- `slug` inside `patch` is **rejected** — slugs are URLs and must stay stable for SEO.
+- `updatedAt` is **always** overwritten with today's date, even if the caller sends one.
+- If `body` is in the patch, `readingTimeMinutes` is recomputed unless explicitly provided.
+- `status` in the patch is honored; omitting it preserves the current status (a tag/category edit won't accidentally unpublish a post).
 
 **Response data**: `{ post: BlogPost }` — the merged record.
 
@@ -197,7 +229,103 @@ Notes:
 
 ---
 
-## 4. Body block format
+### 4.5 `publish` / `unpublish` — toggle status (idempotent)
+
+```ts
+type PublishRequest = { action: 'publish'; slug: string };
+type UnpublishRequest = { action: 'unpublish'; slug: string };
+```
+
+Equivalent to `update` with `patch: { status: 'published' | 'draft' }` but shorter to type and idempotent (already-in-target-state → no write performed).
+
+**Response data**
+
+```ts
+type PublishResponse = { post: BlogPost; changed: boolean };
+```
+
+`changed: false` means the post was already in the requested state and no write was performed (zero side effects). `updatedAt` is only bumped when `changed: true`.
+
+**Errors**: `404 not_found`.
+
+---
+
+### 4.6 `delete` — remove a post permanently
+
+```ts
+type DeleteRequest = { action: 'delete'; slug: string };
+```
+
+Physically removes the row from the store. The post disappears from the listing, sitemap, and detail page on the very next request. **There is no undo** — snapshot the table before bulk deletes.
+
+**Response data**
+
+```ts
+type DeleteResponse = { slug: string; deleted: true };
+```
+
+**Errors**: `404 not_found`.
+
+⚠️ Search engines may still hold the old URL in cache for a while. If a public post had real traffic, consider `unpublish` (returns 404, lets crawlers de-index naturally) before doing a hard `delete`.
+
+---
+
+## 5. `POST /api/blog/upload` — image upload
+
+Upload an image as base64 and get back a public URL you can paste into `coverImage`, an `image` body block, or `author.avatar`.
+
+**Request body**
+
+```ts
+{
+  data: string; // base64; data-URI prefix optional
+  extension: 'png' | 'jpg' | 'jpeg' | 'webp' | 'avif' | 'gif';
+}
+```
+
+- `data` can be either bare base64 (`iVBORw0KG…`) or a full data URI (`data:image/png;base64,iVBORw0KG…`) — the data-URI prefix is stripped automatically.
+- SVG is **intentionally excluded** because it can execute inline scripts when served from the same origin.
+- Max size: **5 MB after decode**. Larger uploads → `413 payload_too_large`.
+
+**Response data**
+
+```ts
+{
+  url: string; // e.g. "/blog/uploads/39cd3061a8674673.png"
+  bytes: number; // decoded size
+  extension: string;
+  contentType: string; // "image/png", etc.
+  existing: boolean; // true if the same bytes were already on disk (no write performed)
+}
+```
+
+- Status is `201` when a new file is written, `200` when content was already present (idempotent).
+- The filename is `<sha256-of-bytes>[0..16].<ext>` — same bytes always resolve to the same URL.
+
+**Errors**
+
+| `error`                | HTTP | Meaning |
+|------------------------|------|---------|
+| `unauthorized`         | 401  | Missing/wrong bearer token. |
+| `invalid_json`         | 400  | Request body wasn't JSON. |
+| `invalid_request`      | 400  | Zod validation failure (e.g. disallowed extension). |
+| `invalid_base64`       | 400  | `data` didn't decode cleanly. |
+| `payload_too_large`    | 413  | Decoded image is > 5 MB. |
+| `storage_write_failed` | 500  | Couldn't write to `public/blog/uploads/`. |
+
+**Example**
+
+```bash
+B64=$(base64 -i my-cover.webp)
+curl -s -X POST https://agilitycreative.com/api/blog/upload \
+  -H "Authorization: Bearer $BLOG_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"data\":\"$B64\",\"extension\":\"webp\"}"
+```
+
+---
+
+## 6. Body block format
 
 `body` is an ordered list of typed blocks. Each block renders to a specific element on `/blog/<slug>`. The renderer lives in `src/components/blog/BlogArticleBody.tsx` — keep that file as the source of truth for visual output.
 
@@ -216,73 +344,83 @@ Block ordering rules of thumb:
 2. Group content under `heading` level 2; reserve level 3 for sub-sections.
 3. Lists work best after a short setup paragraph.
 
-### Minimal example
+### Minimal example (draft → review → publish)
 
-```json
+```bash
+# 1. Upload a cover
+COVER_URL=$(curl -s -X POST $BASE/upload -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"data\":\"$(base64 -i cover.webp)\",\"extension\":\"webp\"}" | jq -r .data.url)
+
+# 2. Create as DRAFT
+curl -s -X POST $BASE -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d "$(cat <<JSON
 {
   "action": "create",
   "post": {
     "title": "O que mudou com Claude 4.7 para devs",
-    "excerpt": "Resumo prático: contexto de 1M, melhor uso de ferramentas, e o que isso muda no fluxo de quem programa todo dia.",
+    "excerpt": "Resumo prático: contexto de 1M, melhor uso de ferramentas...",
     "category": "Inteligência Artificial",
-    "coverImage": "https://placehold.co/1600x900/0a0a0a/4F46E5/png?text=Claude+4.7",
-    "coverAlt": "Logo do Claude com fundo gradiente",
-    "tags": ["ia", "claude", "ferramentas"],
-    "author": { "name": "Equipe Agility", "role": "Editorial" },
+    "coverImage": "$COVER_URL",
+    "coverAlt": "Logo do Claude",
+    "status": "draft",
     "body": [
       { "type": "paragraph", "text": "A nova geração trouxe contexto de 1 milhão de tokens..." },
-      { "type": "heading", "level": 2, "text": "Contexto longo" },
-      { "type": "paragraph", "text": "Você agora pode despejar um repositório inteiro..." },
-      {
-        "type": "list",
-        "ordered": true,
-        "items": [
-          "Quando o contexto longo paga",
-          "Quando RAG ainda é a resposta certa",
-          "O que muda no custo por requisição"
-        ]
-      }
+      { "type": "heading", "level": 2, "text": "Contexto longo" }
     ]
   }
 }
+JSON
+)"
+
+# 3. Review the draft via the API (or stage it however you want)
+curl -s -X POST $BASE -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"read","slug":"o-que-mudou-com-claude-4-7-para-devs"}'
+
+# 4. Ship it
+curl -s -X POST $BASE -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"publish","slug":"o-que-mudou-com-claude-4-7-para-devs"}'
 ```
 
 ---
 
-## 5. Categories & SEO knock-on effects
-
-Creating or updating a post can have ripple effects you should be aware of:
+## 7. Categories & SEO knock-on effects
 
 - **`category` becomes a tab on `/blog`** and an SEO page at `/blog/category/<slug>`. The first time a new label appears (e.g. `"Inteligência Artificial"`), it instantly spawns `/blog/category/inteligencia-artificial`, gets listed in the sitemap on the next request, and shows up in the navbar tabs.
+- Categories are derived from **published posts only** — a draft sitting in a brand-new category does not surface the tab until you publish.
 - Reuse **existing labels verbatim** to avoid creating near-duplicate categories. List the current labels with `list` (the response's `posts[].category` field).
-- **Slug stability is sacred**: once a post exists, its URL is `/blog/<slug>` (often indexed). The API refuses to change `slug` on update for that reason. If you genuinely need to rename, ask a human — they'll need to add an HTTP redirect.
+- **Slug stability is sacred**: once a post exists, its URL is `/blog/<slug>` (often indexed). The API refuses to change `slug` on update for that reason. If you genuinely need to rename, ask a human — they'll add an HTTP redirect.
 - **Locale alternates** (`hreflang`) are emitted automatically for every post — the same record serves both `/blog/<slug>` and `/en/blog/<slug>`. Write the post in the language that matches your audience; the platform doesn't translate.
 
 ---
 
-## 6. Error reference
+## 8. Error reference
 
 | `error` value            | HTTP | Meaning |
 |--------------------------|------|---------|
 | `unauthorized`           | 401  | Missing or wrong bearer token. |
 | `invalid_json`           | 400  | Request body wasn't valid JSON. |
 | `invalid_request`        | 400  | Zod validation failed. Inspect `details.fieldErrors` for per-field issues. |
-| `invalid_slug`           | 400  | Auto-generated slug came out empty (e.g. title was emoji-only). Provide an explicit `slug`. |
+| `invalid_slug`           | 400  | Auto-generated slug came out empty. Provide an explicit `slug`. |
+| `invalid_base64`         | 400  | (upload) `data` didn't decode cleanly. |
 | `not_found`              | 404  | No post matches the requested slug. `details.slug` echoes the input. |
 | `slug_conflict`          | 409  | Tried to create a post whose slug already exists. Switch to `update`. |
+| `payload_too_large`      | 413  | (upload) Decoded image is > 5 MB. |
 | `storage_read_failed`    | 500  | Couldn't read `blog.json`. Check file permissions / disk. |
-| `storage_write_failed`   | 500  | Couldn't write `blog.json`. Same. |
+| `storage_write_failed`   | 500  | Couldn't write to disk. Same. |
 
 ---
 
-## 7. Worked end-to-end example (Node)
+## 9. Worked end-to-end example (Node)
 
 ```js
 const TOKEN = process.env.BLOG_API_TOKEN;
 const BASE = 'https://agilitycreative.com/api/blog';
 
-const call = async (payload) => {
-  const res = await fetch(BASE, {
+const call = async (path, payload) => {
+  const res = await fetch(`${BASE}${path}`, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${TOKEN}`,
@@ -297,16 +435,24 @@ const call = async (payload) => {
   return json.data;
 };
 
-// 1. List current AI posts to avoid title overlap
-const { posts } = await call({ action: 'list', categorySlug: 'inteligencia-artificial' });
+// 1. Upload a cover image
+const fs = await import('node:fs/promises');
+const file = await fs.readFile('./cover.webp');
+const { url: coverUrl } = await call('/upload', {
+  data: file.toString('base64'),
+  extension: 'webp',
+});
 
-// 2. Publish
-const { post } = await call({
+// 2. Create as a draft
+const { post } = await call('', {
   action: 'create',
   post: {
     title: 'Tutorial: rodando Claude na sua CLI em 5 minutos',
-    excerpt: 'Passo-a-passo curto para começar a usar a Claude API no terminal, sem framework.',
+    excerpt: 'Passo-a-passo curto para começar a usar a Claude API no terminal.',
     category: 'Inteligência Artificial',
+    coverImage: coverUrl,
+    coverAlt: 'Terminal com a Claude CLI',
+    status: 'draft',
     tags: ['ia', 'cli', 'tutorial'],
     body: [
       { type: 'paragraph', text: '...' },
@@ -316,40 +462,47 @@ const { post } = await call({
   },
 });
 
-// 3. Later: add a follow-up paragraph
-await call({
-  action: 'update',
-  slug: post.slug,
-  patch: {
-    body: [
-      ...post.body,
-      { type: 'paragraph', text: 'Atualização (junho/2026): suporte oficial ao modelo Haiku 4.5.' },
-    ],
-  },
-});
+// 3. Read it back, decide it's good, publish.
+await call('', { action: 'read', slug: post.slug });
+await call('', { action: 'publish', slug: post.slug });
+
+// 4. Later, take it down if needed.
+await call('', { action: 'unpublish', slug: post.slug });
+
+// 5. Or remove entirely.
+await call('', { action: 'delete', slug: post.slug });
 ```
 
 ---
 
-## 8. Operational caveats
+## 10. Operational caveats
 
-- **Filesystem backing**: edits land in `src/data/blog.json` in the running server's working directory. On Vercel / AWS Lambda / Cloudflare Workers this won't persist across deploys or invocations. Plan to swap `readPosts` / `writePosts` for a real datastore (Postgres, Sanity, KV) before scaling.
+- **Filesystem backing**: post edits land in `src/data/blog.json` and uploads land in `public/blog/uploads/` in the running server's working directory. On Vercel / AWS Lambda / Cloudflare Workers this won't persist across deploys or invocations. Plan to swap `readPosts` / `writePosts` and the upload writer for a real datastore (Postgres + Blob/R2/S3) before scaling.
 - **No revision history**: updates overwrite in place. If you need rollback, snapshot `blog.json` before bulk operations.
-- **No drafts / scheduling**: the moment `create` returns 201, the post is live at `/blog/<slug>` and listed in the sitemap.
-- **No delete**: by design. To pull a post you have to edit `blog.json` by hand and add a 410 (or rewrite) at the server level so search engines de-index.
-- **Single-writer**: the route writes the whole file. Concurrent writes from two agents will race and the last writer wins (other changes lost). Serialize agent calls if you batch.
+- **`delete` is destructive and immediate**. There's no recycle bin and no soft-delete tombstone. Prefer `unpublish` for posts that have been live.
+- **No scheduling**: setting `publishedAt` to a future date does not delay publishing — the post is live the moment `status` is `'published'`. Use `status: 'draft'` to stage and `publish` later (a cron call from your agent works fine).
+- **Single-writer**: each write rewrites the whole file. Concurrent writes from two agents will race and the last writer wins (other changes lost). Serialize agent calls if you batch.
+- **Upload idempotency**: identical bytes → identical URL, no rewrite. You can safely retry uploads without orphaning files.
 
 ---
 
-## 9. Quick local test
+## 11. Quick local test
 
 ```bash
 # in repo root
 TOKEN=$(grep BLOG_API_TOKEN .env.local | cut -d= -f2)
+
+# Sanity check: list published posts.
 curl -s -X POST http://localhost:3000/api/blog \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"action":"list","limit":1}' | jq .
+
+# Upload a 1x1 PNG.
+curl -s -X POST http://localhost:3000/api/blog/upload \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"data":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPj/HwAEOgF/qPCJxQAAAABJRU5ErkJggg==","extension":"png"}' | jq .
 ```
 
-Expected: `{ "ok": true, "data": { "total": N, ... } }`.
+Expected: `{ "ok": true, "data": { ... } }` from both.

--- a/src/app/api/blog/route.test.ts
+++ b/src/app/api/blog/route.test.ts
@@ -1,22 +1,15 @@
-import fs from 'node:fs/promises';
-
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { getPosts, savePosts } from '@/libs/blogStore';
 import type { BlogPost } from '@/types/blog';
 
 import { POST } from './route';
 
-vi.mock('node:fs/promises', () => {
-  const readFile = vi.fn();
-  const writeFile = vi.fn();
-  const rename = vi.fn();
-  return {
-    default: { readFile, writeFile, rename },
-    readFile,
-    writeFile,
-    rename,
-  };
-});
+vi.mock('@/libs/blogStore', () => ({
+  getPosts: vi.fn(),
+  getPostsSafe: vi.fn(),
+  savePosts: vi.fn(),
+}));
 
 const TOKEN = '11111111111111111111111111111111';
 
@@ -27,6 +20,7 @@ const samplePosts = (): BlogPost[] => [
     excerpt: 'Excerpt A long enough',
     publishedAt: '2026-05-01',
     category: 'Produto',
+    status: 'published',
     body: [{ type: 'paragraph', text: 'paragraph a' }],
   },
   {
@@ -35,6 +29,7 @@ const samplePosts = (): BlogPost[] => [
     excerpt: 'Excerpt B long enough',
     publishedAt: '2026-04-01',
     category: 'Design',
+    status: 'published',
     body: [{ type: 'paragraph', text: 'paragraph b' }],
   },
   {
@@ -43,6 +38,7 @@ const samplePosts = (): BlogPost[] => [
     excerpt: 'Excerpt C long enough',
     publishedAt: '2026-03-01',
     category: 'Inteligência Artificial',
+    status: 'draft',
     body: [{ type: 'paragraph', text: 'paragraph c' }],
   },
 ];
@@ -71,9 +67,8 @@ const callPost = async (body: unknown, opts?: Parameters<typeof buildRequest>[1]
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.BLOG_API_TOKEN = TOKEN;
-  vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(samplePosts()));
-  vi.mocked(fs.writeFile).mockResolvedValue(undefined);
-  vi.mocked(fs.rename).mockResolvedValue(undefined);
+  vi.mocked(getPosts).mockResolvedValue(samplePosts());
+  vi.mocked(savePosts).mockResolvedValue(undefined);
 });
 
 describe('POST /api/blog — authentication', () => {
@@ -109,7 +104,7 @@ describe('POST /api/blog — request validation', () => {
   });
 
   it('returns invalid_request for an unknown action', async () => {
-    const { status, body } = await callPost({ action: 'delete', slug: 'foo' });
+    const { status, body } = await callPost({ action: 'archive', slug: 'foo' });
     expect(status).toBe(400);
     expect(body.error).toBe('invalid_request');
     expect(body.details.fieldErrors.action).toBeDefined();
@@ -130,20 +125,20 @@ describe('POST /api/blog — request validation', () => {
 });
 
 describe('POST /api/blog — list', () => {
-  it('returns posts sorted newest first', async () => {
+  it('excludes drafts by default and returns published posts newest first', async () => {
     const { status, body } = await callPost({ action: 'list' });
     expect(status).toBe(200);
-    expect(body.data.total).toBe(3);
+    expect(body.data.total).toBe(2);
     expect(body.data.posts.map((p: { slug: string }) => p.slug)).toEqual([
       'post-a',
       'post-b',
-      'post-c',
     ]);
   });
 
-  it('strips body blocks from the summary payload', async () => {
+  it('strips body blocks but surfaces effective status in the summary', async () => {
     const { body } = await callPost({ action: 'list' });
     expect(body.data.posts[0]).not.toHaveProperty('body');
+    expect(body.data.posts[0].status).toBe('published');
   });
 
   it('filters by exact category label', async () => {
@@ -152,18 +147,41 @@ describe('POST /api/blog — list', () => {
     expect(body.data.posts[0].slug).toBe('post-b');
   });
 
-  it('filters by categorySlug (diacritic-insensitive)', async () => {
+  it('returns drafts when includeDrafts=true', async () => {
+    const { body } = await callPost({ action: 'list', includeDrafts: true });
+    expect(body.data.total).toBe(3);
+    expect(body.data.posts.map((p: { slug: string }) => p.slug)).toContain('post-c');
+  });
+
+  it('returns only drafts when status=draft', async () => {
+    const { body } = await callPost({ action: 'list', status: 'draft' });
+    expect(body.data.total).toBe(1);
+    expect(body.data.posts[0].slug).toBe('post-c');
+    expect(body.data.posts[0].status).toBe('draft');
+  });
+
+  it('respects status filter when combined with categorySlug', async () => {
+    const { body } = await callPost({
+      action: 'list',
+      status: 'draft',
+      categorySlug: 'inteligencia-artificial',
+    });
+    expect(body.data.total).toBe(1);
+    expect(body.data.posts[0].slug).toBe('post-c');
+  });
+
+  it('returns nothing when filtering published in a draft-only category', async () => {
+    // post-c (IA) is the only post in that category and is a draft → 0 hits.
     const { body } = await callPost({
       action: 'list',
       categorySlug: 'inteligencia-artificial',
     });
-    expect(body.data.posts).toHaveLength(1);
-    expect(body.data.posts[0].slug).toBe('post-c');
+    expect(body.data.total).toBe(0);
   });
 
-  it('paginates with limit and offset', async () => {
+  it('paginates with limit and offset (against the filtered set)', async () => {
     const { body } = await callPost({ action: 'list', limit: 1, offset: 1 });
-    expect(body.data.total).toBe(3);
+    expect(body.data.total).toBe(2);
     expect(body.data.count).toBe(1);
     expect(body.data.posts[0].slug).toBe('post-b');
   });
@@ -212,10 +230,9 @@ describe('POST /api/blog — create', () => {
         body: [{ type: 'paragraph', text: 'hi' }],
       },
     });
-    expect(fs.writeFile).toHaveBeenCalledTimes(1);
-    expect(fs.rename).toHaveBeenCalledTimes(1);
-    const written = JSON.parse(vi.mocked(fs.writeFile).mock.calls[0]![1] as string);
-    expect(written[0].slug).toBe('novo-post');
+    expect(savePosts).toHaveBeenCalledTimes(1);
+    const written = vi.mocked(savePosts).mock.calls[0]![0];
+    expect(written[0]!.slug).toBe('novo-post');
     expect(written).toHaveLength(4);
   });
 
@@ -232,7 +249,7 @@ describe('POST /api/blog — create', () => {
     expect(status).toBe(409);
     expect(body.error).toBe('slug_conflict');
     expect(body.details).toEqual({ slug: 'post-a' });
-    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(savePosts).not.toHaveBeenCalled();
   });
 
   it('returns invalid_slug when title slugifies to empty', async () => {
@@ -281,7 +298,7 @@ describe('POST /api/blog — update', () => {
     });
     expect(status).toBe(404);
     expect(body.error).toBe('not_found');
-    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(savePosts).not.toHaveBeenCalled();
   });
 
   it('rejects slug-in-patch', async () => {
@@ -296,16 +313,129 @@ describe('POST /api/blog — update', () => {
   });
 });
 
+describe('POST /api/blog — status defaults on create', () => {
+  it('defaults to status=published when omitted (backward compatible)', async () => {
+    const { body } = await callPost({
+      action: 'create',
+      post: {
+        title: 'Defaults to published',
+        excerpt: 'Excerpt long enough for the validator.',
+        body: [{ type: 'paragraph', text: 'hi' }],
+      },
+    });
+    expect(body.data.post.status).toBe('published');
+  });
+
+  it('honors status=draft when explicitly requested', async () => {
+    const { body } = await callPost({
+      action: 'create',
+      post: {
+        title: 'Starts as draft',
+        excerpt: 'Excerpt long enough for the validator.',
+        status: 'draft',
+        body: [{ type: 'paragraph', text: 'hi' }],
+      },
+    });
+    expect(body.data.post.status).toBe('draft');
+  });
+
+  it('rejects invalid status values', async () => {
+    const { status, body } = await callPost({
+      action: 'create',
+      post: {
+        title: 'Bad status',
+        excerpt: 'Excerpt long enough for the validator.',
+        status: 'archived',
+        body: [{ type: 'paragraph', text: 'hi' }],
+      },
+    });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_request');
+  });
+});
+
+describe('POST /api/blog — publish / unpublish', () => {
+  it('flips a draft to published and bumps updatedAt', async () => {
+    const { status, body } = await callPost({ action: 'publish', slug: 'post-c' });
+    expect(status).toBe(200);
+    expect(body.data.post.status).toBe('published');
+    expect(body.data.post.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(body.data.changed).toBe(true);
+    expect(savePosts).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent — publishing an already-published post does not write', async () => {
+    const { status, body } = await callPost({ action: 'publish', slug: 'post-a' });
+    expect(status).toBe(200);
+    expect(body.data.changed).toBe(false);
+    expect(savePosts).not.toHaveBeenCalled();
+  });
+
+  it('unpublish flips published → draft', async () => {
+    const { body } = await callPost({ action: 'unpublish', slug: 'post-a' });
+    expect(body.data.post.status).toBe('draft');
+    expect(body.data.changed).toBe(true);
+    expect(savePosts).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 404 for an unknown slug', async () => {
+    const { status, body } = await callPost({ action: 'publish', slug: 'nope' });
+    expect(status).toBe(404);
+    expect(body.error).toBe('not_found');
+    expect(savePosts).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/blog — delete', () => {
+  it('removes the post and persists the truncated array', async () => {
+    const { status, body } = await callPost({ action: 'delete', slug: 'post-b' });
+    expect(status).toBe(200);
+    expect(body.data).toEqual({ slug: 'post-b', deleted: true });
+    expect(savePosts).toHaveBeenCalledTimes(1);
+    const written = vi.mocked(savePosts).mock.calls[0]![0];
+    expect(written).toHaveLength(2);
+    expect(written.map(p => p.slug)).not.toContain('post-b');
+  });
+
+  it('returns 404 for an unknown slug', async () => {
+    const { status, body } = await callPost({ action: 'delete', slug: 'nope' });
+    expect(status).toBe(404);
+    expect(body.error).toBe('not_found');
+    expect(savePosts).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/blog — update with status', () => {
+  it('patches status to draft (effectively unpublish via update)', async () => {
+    const { body } = await callPost({
+      action: 'update',
+      slug: 'post-a',
+      patch: { status: 'draft' },
+    });
+    expect(body.data.post.status).toBe('draft');
+  });
+
+  it('preserves existing status when patch omits it', async () => {
+    const { body } = await callPost({
+      action: 'update',
+      slug: 'post-c',
+      patch: { category: 'IA' },
+    });
+    // post-c is a draft; updating an unrelated field must not flip it.
+    expect(body.data.post.status).toBe('draft');
+  });
+});
+
 describe('POST /api/blog — storage errors', () => {
-  it('returns 500 storage_read_failed when readFile throws', async () => {
-    vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('disk gone'));
+  it('returns 500 storage_read_failed when the store read throws', async () => {
+    vi.mocked(getPosts).mockRejectedValueOnce(new Error('db down'));
     const { status, body } = await callPost({ action: 'list' });
     expect(status).toBe(500);
     expect(body.error).toBe('storage_read_failed');
   });
 
   it('returns 500 storage_write_failed when create cannot persist', async () => {
-    vi.mocked(fs.writeFile).mockRejectedValueOnce(new Error('read-only fs'));
+    vi.mocked(savePosts).mockRejectedValueOnce(new Error('db write failed'));
     const { status, body } = await callPost({
       action: 'create',
       post: {

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -1,18 +1,14 @@
-import { Buffer } from 'node:buffer';
-import crypto from 'node:crypto';
-import fs from 'node:fs/promises';
-import path from 'node:path';
-
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { slugifyCategory } from '@/components/blog/categories';
-import type { BlogBodyBlock, BlogPost } from '@/types/blog';
+import { getPosts, savePosts } from '@/libs/blogStore';
+import type { BlogBodyBlock, BlogPost, BlogStatus } from '@/types/blog';
+
+import { isAuthorized } from './auth';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
-
-const BLOG_PATH = path.resolve(process.cwd(), 'src/data/blog.json');
 
 const dateOrIso = z
   .string()
@@ -33,6 +29,8 @@ const imageSrcSchema = z
   .refine(s => s.startsWith('http://') || s.startsWith('https://') || s.startsWith('/'), {
     message: 'must be an absolute URL or a path starting with /',
   });
+
+const statusSchema = z.enum(['draft', 'published']);
 
 const bodyBlockSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('paragraph'), text: z.string().min(1) }),
@@ -82,6 +80,7 @@ const postCreateSchema = z.object({
   category: z.string().min(1).max(60).optional(),
   tags: z.array(z.string().min(1).max(40)).max(20).optional(),
   author: authorSchema.optional(),
+  status: statusSchema.optional(),
   body: z.array(bodyBlockSchema).min(1),
 });
 
@@ -94,12 +93,17 @@ const requestSchema = z.discriminatedUnion('action', [
     action: z.literal('list'),
     category: z.string().optional(),
     categorySlug: z.string().optional(),
+    status: statusSchema.optional(),
+    includeDrafts: z.boolean().optional(),
     limit: z.number().int().positive().max(100).optional(),
     offset: z.number().int().nonnegative().optional(),
   }),
   z.object({ action: z.literal('read'), slug: slugSchema }),
   z.object({ action: z.literal('create'), post: postCreateSchema }),
   z.object({ action: z.literal('update'), slug: slugSchema, patch: postPatchSchema }),
+  z.object({ action: z.literal('publish'), slug: slugSchema }),
+  z.object({ action: z.literal('unpublish'), slug: slugSchema }),
+  z.object({ action: z.literal('delete'), slug: slugSchema }),
 ]);
 
 const slugifyTitle = (title: string) =>
@@ -137,54 +141,60 @@ const estimateReadingTime = (blocks: BlogBodyBlock[]) => {
 
 const today = () => new Date().toISOString().slice(0, 10);
 
+// Normalize a stored post's status — legacy posts without the field are
+// "published" by grandfather rule. Surface it explicitly in API responses
+// so callers don't have to interpret undefined.
+const effectiveStatus = (post: BlogPost): BlogStatus =>
+  post.status ?? 'published';
+
 const summarize = (post: BlogPost) => ({
   slug: post.slug,
   title: post.title,
   excerpt: post.excerpt,
   category: post.category,
+  status: effectiveStatus(post),
   publishedAt: post.publishedAt,
   updatedAt: post.updatedAt,
   readingTimeMinutes: post.readingTimeMinutes,
   coverImage: post.coverImage,
 });
 
-const isAuthorized = (req: Request) => {
-  const expected = process.env.BLOG_API_TOKEN;
-  if (!expected) {
-    return false;
-  }
-  const header = req.headers.get('authorization') ?? '';
-  // Anchored single-space separator avoids super-linear backtracking on \s+(.+).
-  const match = /^Bearer (\S.*)$/i.exec(header);
-  if (!match || !match[1]) {
-    return false;
-  }
-  const provided = match[1].trim();
-  const expectedBuf = Buffer.from(expected);
-  const providedBuf = Buffer.from(provided);
-  if (expectedBuf.length !== providedBuf.length) {
-    return false;
-  }
-  try {
-    return crypto.timingSafeEqual(expectedBuf, providedBuf);
-  } catch {
-    return false;
-  }
-};
-
-const readPosts = async (): Promise<BlogPost[]> => {
-  const raw = await fs.readFile(BLOG_PATH, 'utf8');
-  return JSON.parse(raw) as BlogPost[];
-};
-
-const writePosts = async (posts: BlogPost[]) => {
-  const tmp = `${BLOG_PATH}.tmp`;
-  await fs.writeFile(tmp, `${JSON.stringify(posts, null, 2)}\n`, 'utf8');
-  await fs.rename(tmp, BLOG_PATH);
-};
+// Armazenamento agora é Postgres (ver src/libs/blogStore). Mantemos os mesmos
+// nomes readPosts/writePosts para não tocar no resto do handler.
+const readPosts = getPosts;
+const writePosts = savePosts;
 
 const errorResponse = (status: number, error: string, details?: unknown) =>
   NextResponse.json({ ok: false, error, ...(details === undefined ? {} : { details }) }, { status });
+
+const setStatusAndPersist = async (
+  posts: BlogPost[],
+  slug: string,
+  nextStatus: BlogStatus,
+) => {
+  const index = posts.findIndex(p => p.slug === slug);
+  if (index === -1) {
+    return { ok: false as const, error: 'not_found' as const };
+  }
+  const current = posts[index]!;
+  if (effectiveStatus(current) === nextStatus) {
+    // Idempotent — no write, return current post.
+    return { ok: true as const, post: current, changed: false };
+  }
+  const merged: BlogPost = {
+    ...current,
+    status: nextStatus,
+    updatedAt: today(),
+  };
+  const next = [...posts];
+  next[index] = merged;
+  try {
+    await writePosts(next);
+  } catch {
+    return { ok: false as const, error: 'storage_write_failed' as const };
+  }
+  return { ok: true as const, post: merged, changed: true };
+};
 
 export async function POST(req: Request) {
   if (!isAuthorized(req)) {
@@ -214,7 +224,18 @@ export async function POST(req: Request) {
 
   switch (command.action) {
     case 'list': {
+      const wantsDrafts = command.includeDrafts === true || command.status === 'draft';
       const filtered = posts.filter((post) => {
+        // Status filter: by default, only published. Caller can request drafts
+        // explicitly with includeDrafts=true (returns both) or status='draft'
+        // (returns only drafts).
+        if (command.status) {
+          if (effectiveStatus(post) !== command.status) {
+            return false;
+          }
+        } else if (!wantsDrafts && effectiveStatus(post) === 'draft') {
+          return false;
+        }
         if (command.categorySlug) {
           return post.category ? slugifyCategory(post.category) === command.categorySlug : false;
         }
@@ -246,7 +267,10 @@ export async function POST(req: Request) {
       if (!post) {
         return errorResponse(404, 'not_found', { slug: command.slug });
       }
-      return NextResponse.json({ ok: true, data: { post } });
+      return NextResponse.json({
+        ok: true,
+        data: { post: { ...post, status: effectiveStatus(post) } },
+      });
     }
 
     case 'create': {
@@ -258,6 +282,8 @@ export async function POST(req: Request) {
       if (posts.some(p => p.slug === slug)) {
         return errorResponse(409, 'slug_conflict', { slug });
       }
+      // Backward-compatible default: status omitted means 'published'. The
+      // agent opts into drafts explicitly by sending status: 'draft'.
       const newPost: BlogPost = {
         slug,
         title: input.title,
@@ -270,6 +296,7 @@ export async function POST(req: Request) {
         category: input.category,
         tags: input.tags,
         author: input.author,
+        status: input.status ?? 'published',
         body: input.body,
       };
       const next = [newPost, ...posts];
@@ -294,6 +321,8 @@ export async function POST(req: Request) {
         slug: current.slug,
         updatedAt: today(),
         body: patch.body ?? current.body,
+        // Preserve current status unless patch explicitly sets it.
+        status: patch.status ?? effectiveStatus(current),
       };
       if (patch.body) {
         merged.readingTimeMinutes = patch.readingTimeMinutes ?? estimateReadingTime(patch.body);
@@ -306,6 +335,40 @@ export async function POST(req: Request) {
         return errorResponse(500, 'storage_write_failed');
       }
       return NextResponse.json({ ok: true, data: { post: merged } });
+    }
+
+    case 'publish':
+    case 'unpublish': {
+      const target: BlogStatus = command.action === 'publish' ? 'published' : 'draft';
+      const result = await setStatusAndPersist(posts, command.slug, target);
+      if (!result.ok) {
+        if (result.error === 'not_found') {
+          return errorResponse(404, 'not_found', { slug: command.slug });
+        }
+        return errorResponse(500, result.error);
+      }
+      return NextResponse.json({
+        ok: true,
+        data: { post: result.post, changed: result.changed },
+      });
+    }
+
+    case 'delete': {
+      const index = posts.findIndex(p => p.slug === command.slug);
+      if (index === -1) {
+        return errorResponse(404, 'not_found', { slug: command.slug });
+      }
+      const removed = posts[index]!;
+      const next = posts.filter((_, i) => i !== index);
+      try {
+        await writePosts(next);
+      } catch {
+        return errorResponse(500, 'storage_write_failed');
+      }
+      return NextResponse.json({
+        ok: true,
+        data: { slug: removed.slug, deleted: true },
+      });
     }
   }
 }

--- a/src/app/api/blog/upload/route.test.ts
+++ b/src/app/api/blog/upload/route.test.ts
@@ -1,0 +1,162 @@
+import { Buffer } from 'node:buffer';
+import fs from 'node:fs/promises';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { POST } from './route';
+
+vi.mock('node:fs/promises', () => {
+  const access = vi.fn();
+  const mkdir = vi.fn();
+  const writeFile = vi.fn();
+  const rename = vi.fn();
+  return {
+    default: { access, mkdir, writeFile, rename },
+    access,
+    mkdir,
+    writeFile,
+    rename,
+  };
+});
+
+const TOKEN = '22222222222222222222222222222222';
+
+const buildRequest = (
+  body: unknown,
+  { token = TOKEN, raw }: { token?: string | null; raw?: string } = {},
+) => {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== null) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return new Request('http://localhost/api/blog/upload', {
+    method: 'POST',
+    headers,
+    body: raw ?? JSON.stringify(body),
+  });
+};
+
+const callPost = async (body: unknown, opts?: Parameters<typeof buildRequest>[1]) => {
+  const res = await POST(buildRequest(body, opts));
+  const json = await res.json();
+  return { status: res.status, body: json };
+};
+
+// 1×1 transparent PNG — smallest valid image payload we can ship as a fixture.
+const TINY_PNG_BASE64
+  = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPj/HwAEOgF/qPCJxQAAAABJRU5ErkJggg==';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.BLOG_API_TOKEN = TOKEN;
+  vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+  vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+  vi.mocked(fs.rename).mockResolvedValue(undefined);
+  // Default: file does not exist yet. Tests that need the "already there"
+  // path override this with mockResolvedValueOnce(undefined).
+  vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+});
+
+describe('POST /api/blog/upload — authentication', () => {
+  it('rejects requests without a token', async () => {
+    const { status } = await callPost(
+      { data: TINY_PNG_BASE64, extension: 'png' },
+      { token: null },
+    );
+    expect(status).toBe(401);
+  });
+
+  it('rejects requests with the wrong token', async () => {
+    const { status } = await callPost(
+      { data: TINY_PNG_BASE64, extension: 'png' },
+      { token: 'wrong' },
+    );
+    expect(status).toBe(401);
+  });
+});
+
+describe('POST /api/blog/upload — validation', () => {
+  it('returns invalid_json when the body is not JSON', async () => {
+    const { status, body } = await callPost(undefined, { raw: 'not-json' });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_json');
+  });
+
+  it('returns invalid_request when the extension is not in the allowlist', async () => {
+    const { status, body } = await callPost({ data: TINY_PNG_BASE64, extension: 'svg' });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_request');
+  });
+
+  it('returns invalid_base64 for garbage payloads', async () => {
+    const { status, body } = await callPost({
+      data: '@@@not-base64@@@',
+      extension: 'png',
+    });
+    expect(status).toBe(400);
+    expect(body.error).toBe('invalid_base64');
+  });
+
+  it('returns payload_too_large for over-budget uploads', async () => {
+    // 6MB of zeros, base64-encoded → 8MB string. Trips the 5MB ceiling.
+    const buffer = Buffer.alloc(6 * 1024 * 1024, 0);
+    const { status, body } = await callPost({
+      data: buffer.toString('base64'),
+      extension: 'png',
+    });
+    expect(status).toBe(413);
+    expect(body.error).toBe('payload_too_large');
+  });
+});
+
+describe('POST /api/blog/upload — happy path', () => {
+  it('writes a content-addressed file and returns a public URL', async () => {
+    const { status, body } = await callPost({ data: TINY_PNG_BASE64, extension: 'png' });
+    expect(status).toBe(201);
+    expect(body.ok).toBe(true);
+    expect(body.data.url).toMatch(/^\/blog\/uploads\/[a-f0-9]{16}\.png$/);
+    expect(body.data.extension).toBe('png');
+    expect(body.data.contentType).toBe('image/png');
+    expect(body.data.existing).toBe(false);
+    expect(fs.mkdir).toHaveBeenCalledWith(
+      expect.stringContaining('public/blog/uploads'),
+      { recursive: true },
+    );
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    expect(fs.rename).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips the data-URI prefix before decoding', async () => {
+    const { status, body } = await callPost({
+      data: `data:image/png;base64,${TINY_PNG_BASE64}`,
+      extension: 'png',
+    });
+    expect(status).toBe(201);
+    expect(body.data.url).toMatch(/\.png$/);
+  });
+
+  it('short-circuits when the same content already exists', async () => {
+    vi.mocked(fs.access).mockResolvedValueOnce(undefined);
+    const { status, body } = await callPost({ data: TINY_PNG_BASE64, extension: 'png' });
+    expect(status).toBe(200);
+    expect(body.data.existing).toBe(true);
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(fs.rename).not.toHaveBeenCalled();
+  });
+
+  it('produces the same URL for identical content (idempotent)', async () => {
+    const first = await callPost({ data: TINY_PNG_BASE64, extension: 'png' });
+    vi.mocked(fs.access).mockResolvedValueOnce(undefined);
+    const second = await callPost({ data: TINY_PNG_BASE64, extension: 'png' });
+    expect(first.body.data.url).toBe(second.body.data.url);
+  });
+});
+
+describe('POST /api/blog/upload — storage errors', () => {
+  it('returns 500 storage_write_failed when writeFile throws', async () => {
+    vi.mocked(fs.writeFile).mockRejectedValueOnce(new Error('disk full'));
+    const { status, body } = await callPost({ data: TINY_PNG_BASE64, extension: 'png' });
+    expect(status).toBe(500);
+    expect(body.error).toBe('storage_write_failed');
+  });
+});

--- a/src/app/api/blog/upload/route.ts
+++ b/src/app/api/blog/upload/route.ts
@@ -1,0 +1,142 @@
+import { Buffer } from 'node:buffer';
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { isAuthorized } from '../auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// 5MB after base64 decode — covers full-bleed blog covers, blocks reckless uploads.
+const MAX_BYTES = 5 * 1024 * 1024;
+
+// SVG is intentionally excluded: it can carry inline scripts and would
+// execute when served from /public on the same origin as the app.
+const ALLOWED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp', 'avif', 'gif'] as const;
+
+type Extension = (typeof ALLOWED_EXTENSIONS)[number];
+
+const EXTENSION_TO_CONTENT_TYPE: Record<Extension, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+  avif: 'image/avif',
+  gif: 'image/gif',
+};
+
+const requestSchema = z.object({
+  // Base64-encoded image. The data-URI prefix ("data:image/png;base64,") is
+  // optional — it's stripped if present so callers can paste either form.
+  data: z.string().min(1),
+  extension: z.enum(ALLOWED_EXTENSIONS),
+});
+
+const errorResponse = (status: number, error: string, details?: unknown) =>
+  NextResponse.json({ ok: false, error, ...(details === undefined ? {} : { details }) }, { status });
+
+const stripDataUri = (data: string) => {
+  const match = /^data:[^;]+;base64,(.+)$/.exec(data);
+  return match?.[1] ?? data;
+};
+
+const UPLOAD_DIR = path.resolve(process.cwd(), 'public', 'blog', 'uploads');
+const PUBLIC_URL_PREFIX = '/blog/uploads';
+
+export async function POST(req: Request) {
+  if (!isAuthorized(req)) {
+    return errorResponse(401, 'unauthorized');
+  }
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return errorResponse(400, 'invalid_json');
+  }
+
+  const parsed = requestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return errorResponse(400, 'invalid_request', parsed.error.flatten());
+  }
+
+  const { extension } = parsed.data;
+  const base64 = stripDataUri(parsed.data.data);
+
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(base64, 'base64');
+  } catch {
+    return errorResponse(400, 'invalid_base64');
+  }
+
+  // Buffer.from with an invalid base64 input silently produces a short buffer
+  // instead of throwing — re-encode and compare to catch garbage payloads.
+  if (buffer.length === 0 || buffer.toString('base64').replace(/=+$/, '') !== base64.replace(/=+$/, '')) {
+    return errorResponse(400, 'invalid_base64');
+  }
+
+  if (buffer.length > MAX_BYTES) {
+    return errorResponse(413, 'payload_too_large', { bytes: buffer.length, maxBytes: MAX_BYTES });
+  }
+
+  // Content-addressed filename — uploading the same image twice yields the
+  // same URL. 16 hex chars of sha256 = 64 bits of entropy, ample for blog use.
+  const hash = crypto.createHash('sha256').update(buffer).digest('hex').slice(0, 16);
+  const filename = `${hash}.${extension}`;
+  const targetPath = path.join(UPLOAD_DIR, filename);
+  const publicUrl = `${PUBLIC_URL_PREFIX}/${filename}`;
+
+  try {
+    await fs.mkdir(UPLOAD_DIR, { recursive: true });
+  } catch {
+    return errorResponse(500, 'storage_write_failed');
+  }
+
+  // Short-circuit if the same content already exists — avoid a redundant write.
+  try {
+    await fs.access(targetPath);
+    return NextResponse.json(
+      {
+        ok: true,
+        data: {
+          url: publicUrl,
+          bytes: buffer.length,
+          extension,
+          contentType: EXTENSION_TO_CONTENT_TYPE[extension],
+          existing: true,
+        },
+      },
+    );
+  } catch {
+    // file doesn't exist — fall through to write.
+  }
+
+  // Atomic write: temp file → rename. Avoids serving a half-written image
+  // if the request is interrupted mid-flight.
+  const tmpPath = `${targetPath}.tmp`;
+  try {
+    await fs.writeFile(tmpPath, buffer);
+    await fs.rename(tmpPath, targetPath);
+  } catch {
+    return errorResponse(500, 'storage_write_failed');
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      data: {
+        url: publicUrl,
+        bytes: buffer.length,
+        extension,
+        contentType: EXTENSION_TO_CONTENT_TYPE[extension],
+        existing: false,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,9 @@
 import type { MetadataRoute } from 'next';
 
 import { getAllCategorySlugs } from '@/components/blog/categories';
-import blogData from '@/data/blog.json';
 import portfolioData from '@/data/portfolio.json';
-import type { BlogPost } from '@/types/blog';
+import { getPostsSafe } from '@/libs/blogStore';
+import { isPublished } from '@/types/blog';
 import type { Project } from '@/types/portfolio';
 import { AppConfig } from '@/utils/AppConfig';
 import { localizedUrl } from '@/utils/seo';
@@ -30,7 +30,9 @@ const buildLanguageAlternates = (path: string) => {
   return languages;
 };
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export const dynamic = 'force-dynamic';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
   const entries: MetadataRoute.Sitemap = [];
 
@@ -75,7 +77,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
   }
 
   // Blog article pages, one row per locale, lastModified from the post itself.
-  const blogPosts = blogData as BlogPost[];
+  // Drafts (status: 'draft') stay out of the sitemap.
+  const blogPosts = (await getPostsSafe()).filter(isPublished);
   for (const post of blogPosts) {
     const blogPath = `/blog/${post.slug}`;
     const lastModified = new Date(post.updatedAt ?? post.publishedAt);

--- a/src/components/blog/BlogArticleBody.tsx
+++ b/src/components/blog/BlogArticleBody.tsx
@@ -7,21 +7,42 @@ type BlogArticleBodyProps = {
 };
 
 const BlogArticleBody = ({ blocks }: BlogArticleBodyProps) => {
+  // Identify the index of the first paragraph so we can style it as the lede
+  // (no drop-cap — they read garish on the web — but a slightly larger size).
+  const firstParagraphIndex = blocks.findIndex(b => b.type === 'paragraph');
+
   return (
-    <div className="space-y-6 text-[17px] leading-[1.75] text-neutral-700">
+    <div className="space-y-7 text-[18px] leading-[1.8] text-stone-700">
       {blocks.map((block, index) => {
         switch (block.type) {
           case 'paragraph':
-            return <p key={index}>{block.text}</p>;
+            return (
+              <p
+                key={index}
+                className={
+                  index === firstParagraphIndex
+                    ? 'text-[20px] leading-[1.7] text-stone-800'
+                    : ''
+                }
+              >
+                {block.text}
+              </p>
+            );
           case 'heading':
             return block.level === 3
               ? (
-                  <h3 key={index} className="mt-10 text-xl font-semibold text-neutral-900">
+                  <h3
+                    key={index}
+                    className="mt-12 text-[20px] font-semibold tracking-[-0.01em] text-stone-900"
+                  >
                     {block.text}
                   </h3>
                 )
               : (
-                  <h2 key={index} className="mt-12 text-2xl font-semibold text-neutral-900 md:text-[1.75rem]">
+                  <h2
+                    key={index}
+                    className="mt-16 text-[26px] font-semibold leading-tight tracking-[-0.02em] text-stone-900 md:text-[30px]"
+                  >
                     {block.text}
                   </h2>
                 );
@@ -30,10 +51,10 @@ const BlogArticleBody = ({ blocks }: BlogArticleBodyProps) => {
             return (
               <Tag
                 key={index}
-                className={`${block.ordered ? 'list-decimal' : 'list-disc'} space-y-2 pl-6 marker:text-primary`}
+                className={`${block.ordered ? 'list-decimal' : 'list-disc'} space-y-2.5 pl-6 marker:font-semibold marker:text-stone-400`}
               >
                 {block.items.map((item, itemIndex) => (
-                  <li key={itemIndex}>{item}</li>
+                  <li key={itemIndex} className="pl-1">{item}</li>
                 ))}
               </Tag>
             );
@@ -42,15 +63,15 @@ const BlogArticleBody = ({ blocks }: BlogArticleBodyProps) => {
             return (
               <blockquote
                 key={index}
-                className="my-10 border-l-2 border-primary py-2 pl-6 text-xl font-medium leading-snug text-neutral-900"
+                className="my-12 border-l-[3px] border-primary/80 py-2 pl-8 pr-2"
               >
-                <p>
+                <p className="text-[22px] font-medium leading-snug tracking-[-0.01em] text-stone-900">
                   &ldquo;
                   {block.text}
                   &rdquo;
                 </p>
                 {block.cite && (
-                  <cite className="mt-3 block text-sm not-italic text-neutral-500">
+                  <cite className="mt-4 block text-[11px] font-semibold uppercase tracking-[0.18em] not-italic text-stone-400">
                     —
                     {' '}
                     {block.cite}
@@ -60,7 +81,10 @@ const BlogArticleBody = ({ blocks }: BlogArticleBodyProps) => {
             );
           case 'image':
             return (
-              <figure key={index} className="my-10 overflow-hidden rounded-xl border border-neutral-200">
+              <figure
+                key={index}
+                className="my-12 overflow-hidden rounded-2xl ring-1 ring-stone-200/70"
+              >
                 <Image
                   src={block.src}
                   alt={block.alt}
@@ -70,7 +94,7 @@ const BlogArticleBody = ({ blocks }: BlogArticleBodyProps) => {
                   className="h-auto w-full"
                 />
                 {block.caption && (
-                  <figcaption className="bg-neutral-50 px-4 py-3 text-center text-sm text-neutral-500">
+                  <figcaption className="bg-stone-50 px-5 py-3 text-center text-[13px] text-stone-500">
                     {block.caption}
                   </figcaption>
                 )}
@@ -80,7 +104,7 @@ const BlogArticleBody = ({ blocks }: BlogArticleBodyProps) => {
             return (
               <pre
                 key={index}
-                className="overflow-x-auto rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm leading-relaxed text-neutral-800"
+                className="my-8 overflow-x-auto rounded-2xl bg-stone-900 p-5 text-[13px] leading-relaxed text-stone-100 ring-1 ring-stone-900/10"
               >
                 <code>{block.code}</code>
               </pre>

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -28,34 +28,50 @@ const BlogCard = ({ item, locale }: BlogCardProps) => {
   return (
     <Link
       href={`/blog/${item.slug}`}
-      className="group flex h-full flex-col gap-5 rounded-2xl border border-neutral-200 bg-white p-6 transition-colors hover:border-neutral-300"
+      className="group flex h-full flex-col gap-6 rounded-2xl border border-stone-200/70 bg-white p-6 shadow-[0_1px_2px_rgba(0,0,0,0.02)] transition-all duration-300 hover:-translate-y-0.5 hover:border-stone-300/70 hover:shadow-[0_12px_28px_-12px_rgba(0,0,0,0.12),0_4px_10px_-6px_rgba(0,0,0,0.06)]"
     >
-      <div className="flex items-center gap-2 text-[11px] font-semibold tracking-[0.12em] text-neutral-500">
+      <div className="flex items-center gap-2.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-stone-400">
         <span>{dateLabel}</span>
         {item.category && (
           <>
-            <span aria-hidden className="text-neutral-300">·</span>
-            <span className="uppercase text-primary">{item.category}</span>
+            <span aria-hidden className="size-1 rounded-full bg-stone-300" />
+            <span className="text-primary">{item.category}</span>
           </>
         )}
       </div>
 
-      <div className="flex flex-1 items-start gap-4">
-        <h3 className="flex-1 text-base font-semibold leading-snug text-neutral-900 transition-colors group-hover:text-primary">
-          {item.title}
-        </h3>
+      <div className="flex flex-1 items-start gap-5">
+        <div className="flex-1">
+          <h3 className="text-[17px] font-semibold leading-snug tracking-[-0.01em] text-stone-900 transition-colors duration-300 group-hover:text-primary">
+            {item.title}
+          </h3>
+          <p className="mt-2.5 line-clamp-2 text-[13px] leading-relaxed text-stone-500">
+            {item.excerpt}
+          </p>
+        </div>
         {item.coverImage && (
-          <div className="relative size-20 shrink-0 overflow-hidden rounded-lg bg-neutral-100">
+          <div className="relative size-[88px] shrink-0 overflow-hidden rounded-xl bg-stone-100 ring-1 ring-inset ring-black/[0.04]">
             <Image
               src={item.coverImage}
               alt={item.coverAlt ?? item.title}
               fill
-              sizes="80px"
-              className="object-cover transition-transform duration-500 group-hover:scale-[1.05]"
+              sizes="88px"
+              className="object-cover transition-transform duration-[900ms] ease-out group-hover:scale-[1.06]"
             />
           </div>
         )}
       </div>
+
+      {item.readingTimeMinutes && (
+        <div className="flex items-center gap-2 text-[11px] text-stone-400">
+          <span aria-hidden className="h-px w-4 bg-stone-200" />
+          <span>
+            {item.readingTimeMinutes}
+            {' '}
+            min
+          </span>
+        </div>
+      )}
     </Link>
   );
 };

--- a/src/components/blog/BlogCategoryTabs.tsx
+++ b/src/components/blog/BlogCategoryTabs.tsx
@@ -31,10 +31,10 @@ const BlogCategoryTabs = ({
   return (
     <nav
       aria-label="Blog categories"
-      className="-mx-4 border-b border-neutral-200 px-4 sm:mx-0 sm:px-0"
+      className="relative -mx-5 border-b border-stone-200/70 px-5 sm:mx-0 sm:px-0"
     >
       <ul
-        className="flex h-12 min-w-max items-stretch gap-1 overflow-x-auto overflow-y-hidden sm:gap-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="flex h-14 min-w-max items-stretch gap-1 overflow-x-auto overflow-y-hidden sm:gap-3 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {items.map((item) => {
           const isActive = item.slug === activeSlug;
@@ -44,17 +44,17 @@ const BlogCategoryTabs = ({
                 href={item.href}
                 aria-current={isActive ? 'page' : undefined}
                 className={classNames(
-                  'relative inline-flex items-center whitespace-nowrap px-3 text-sm transition-colors',
+                  'relative inline-flex items-center whitespace-nowrap px-2 text-[13px] tracking-tight transition-colors',
                   isActive
-                    ? 'font-semibold text-neutral-900'
-                    : 'font-medium text-neutral-500 hover:text-neutral-900',
+                    ? 'font-semibold text-stone-900'
+                    : 'font-medium text-stone-500 hover:text-stone-900',
                 )}
               >
                 {item.label}
                 {isActive && (
                   <span
                     aria-hidden
-                    className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-primary"
+                    className="absolute inset-x-2 -bottom-px h-[2px] rounded-t-full bg-stone-900"
                   />
                 )}
               </Link>

--- a/src/components/blog/BlogFeaturedCard.tsx
+++ b/src/components/blog/BlogFeaturedCard.tsx
@@ -19,47 +19,52 @@ const BlogFeaturedCard = ({ item, locale, readArticleLabel }: BlogFeaturedCardPr
   return (
     <Link
       href={`/blog/${item.slug}`}
-      className="group grid grid-cols-1 overflow-hidden rounded-2xl border border-neutral-200 bg-white transition-colors hover:border-neutral-300 lg:grid-cols-[1.6fr_1fr]"
+      className="group relative grid grid-cols-1 overflow-hidden rounded-3xl border border-stone-200/70 bg-white shadow-[0_1px_2px_rgba(0,0,0,0.02)] transition-all duration-500 hover:-translate-y-0.5 hover:border-stone-300/70 hover:shadow-[0_24px_60px_-20px_rgba(0,0,0,0.18),0_8px_20px_-12px_rgba(0,0,0,0.08)] lg:grid-cols-[1.55fr_1fr]"
     >
       {item.coverImage
         ? (
-            <div className="relative aspect-[16/10] overflow-hidden bg-gradient-to-br from-neutral-50 to-neutral-100 lg:aspect-auto">
+            <div className="relative aspect-[16/10] overflow-hidden bg-gradient-to-br from-stone-100 to-stone-50 lg:aspect-auto">
               <Image
                 src={item.coverImage}
                 alt={item.coverAlt ?? item.title}
                 fill
                 sizes="(max-width: 1024px) 100vw, 60vw"
-                className="object-cover transition-transform duration-500 group-hover:scale-[1.02]"
+                className="object-cover transition-transform duration-[1200ms] ease-out group-hover:scale-[1.04]"
                 priority
+              />
+              {/* Subtle inner vignette — gives the image more depth without darkening it. */}
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-black/[0.04]"
               />
             </div>
           )
         : (
-            <div className="aspect-[16/10] bg-gradient-to-br from-neutral-100 to-neutral-50 lg:aspect-auto" />
+            <div className="aspect-[16/10] bg-gradient-to-br from-stone-100 to-stone-50 lg:aspect-auto" />
           )}
 
-      <div className="flex flex-col justify-center gap-5 p-8 md:p-10 lg:p-12">
-        <div className="flex items-center gap-2 text-xs font-semibold tracking-[0.12em] text-neutral-500">
+      <div className="flex flex-col justify-center gap-6 p-8 md:p-12 lg:p-14">
+        <div className="flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400">
           <span>{dateLabel}</span>
           {item.category && (
             <>
-              <span aria-hidden className="text-neutral-300">/</span>
-              <span className="uppercase text-primary">{item.category}</span>
+              <span aria-hidden className="size-1 rounded-full bg-stone-300" />
+              <span className="text-primary">{item.category}</span>
             </>
           )}
         </div>
 
-        <h2 className="text-3xl font-bold leading-[1.15] tracking-tight text-neutral-900 transition-colors group-hover:text-primary md:text-4xl">
+        <h2 className="text-[1.875rem] font-semibold leading-[1.1] tracking-[-0.02em] text-stone-900 transition-colors duration-300 md:text-[2.25rem] lg:text-[2.5rem]">
           {item.title}
         </h2>
 
-        <p className="line-clamp-3 text-base leading-relaxed text-neutral-600">
+        <p className="line-clamp-3 text-[15px] leading-relaxed text-stone-500">
           {item.excerpt}
         </p>
 
-        <span className="mt-2 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-neutral-900">
+        <span className="mt-2 inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-900">
           {readArticleLabel}
-          <span className="inline-flex size-7 items-center justify-center rounded-full bg-neutral-900 text-white transition-transform group-hover:translate-x-1">
+          <span className="inline-flex size-8 items-center justify-center rounded-full bg-stone-900 text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-transform duration-300 group-hover:translate-x-1">
             <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
               <line x1="5" y1="12" x2="19" y2="12" />
               <polyline points="12 5 19 12 12 19" />

--- a/src/components/blog/BlogFooter.tsx
+++ b/src/components/blog/BlogFooter.tsx
@@ -9,37 +9,90 @@ const BlogFooter = () => {
   const tBlog = useTranslations('BlogPage');
 
   return (
-    <footer className="border-t border-neutral-200 bg-white py-12">
-      <div className="mx-auto flex max-w-5xl flex-col items-start justify-between gap-6 px-4 sm:flex-row sm:items-center sm:px-6">
-        <Link href="/" className="flex items-center gap-2.5">
-          <Image src="/assets/images/logo/logo_symbol_black.svg" alt="Agility" width={24} height={24} />
-          <Image src="/assets/images/logo/logo_name_black.svg" alt="Agility" width={76} height={20} />
-        </Link>
+    <footer className="relative border-t border-stone-200/70 bg-stone-50">
+      <div className="mx-auto max-w-6xl px-5 py-16 sm:px-8 md:py-20">
+        <div className="grid grid-cols-1 gap-12 md:grid-cols-[1.4fr_1fr_1fr]">
+          <div className="max-w-sm">
+            <Link href="/" className="inline-flex items-center gap-2.5">
+              <Image src="/assets/images/logo/logo_symbol_black.svg" alt="Agility" width={28} height={28} />
+              <Image src="/assets/images/logo/logo_name_black.svg" alt="Agility" width={92} height={22} />
+            </Link>
+            <p className="mt-5 text-sm leading-relaxed text-stone-500">
+              {t('tagline')}
+            </p>
+          </div>
 
-        <nav className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-neutral-500">
-          <Link href="/blog" className="transition-colors hover:text-neutral-900">
-            {tBlog('badge')}
-          </Link>
-          <Link href="/portfolio" className="transition-colors hover:text-neutral-900">
-            {tNav('portfolio')}
-          </Link>
-          <Link href="/sobre-nos" className="transition-colors hover:text-neutral-900">
-            {tNav('about')}
-          </Link>
-          <a href="mailto:hi@agilitycreative.com" className="transition-colors hover:text-neutral-900">
-            hi@agilitycreative.com
-          </a>
-        </nav>
+          <div>
+            <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400">
+              {t('navigation')}
+            </p>
+            <ul className="space-y-2.5 text-sm">
+              <li>
+                <Link href="/blog" className="text-stone-600 transition-colors hover:text-stone-900">
+                  {tBlog('badge')}
+                </Link>
+              </li>
+              <li>
+                <Link href="/portfolio" className="text-stone-600 transition-colors hover:text-stone-900">
+                  {tNav('portfolio')}
+                </Link>
+              </li>
+              <li>
+                <Link href="/sobre-nos" className="text-stone-600 transition-colors hover:text-stone-900">
+                  {tNav('about')}
+                </Link>
+              </li>
+              <li>
+                <Link href="/" className="text-stone-600 transition-colors hover:text-stone-900">
+                  {tNav('home')}
+                </Link>
+              </li>
+            </ul>
+          </div>
 
-        <p className="text-xs text-neutral-400">
-          ©
-          {' '}
-          {new Date().getFullYear()}
-          {' '}
-          Agility Creative.
-          {' '}
-          {t('copyright')}
-        </p>
+          <div>
+            <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400">
+              {t('contact')}
+            </p>
+            <ul className="space-y-2.5 text-sm">
+              <li>
+                <a href="mailto:hi@agilitycreative.com" className="text-stone-600 transition-colors hover:text-stone-900">
+                  hi@agilitycreative.com
+                </a>
+              </li>
+              <li>
+                <a href="tel:+5585996284730" className="text-stone-600 transition-colors hover:text-stone-900">
+                  +55 85 99628-4730
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://instagram.com/agilitycreative"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-stone-600 transition-colors hover:text-stone-900"
+                >
+                  @agilitycreative
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="mt-14 flex flex-col items-start justify-between gap-3 border-t border-stone-200/70 pt-6 sm:flex-row sm:items-center">
+          <p className="text-xs text-stone-400">
+            ©
+            {' '}
+            {new Date().getFullYear()}
+            {' '}
+            Agility Creative.
+            {' '}
+            {t('copyright')}
+          </p>
+          <p className="text-xs uppercase tracking-[0.18em] text-stone-400">
+            Fortaleza · Brasil
+          </p>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/blog/BlogHeader.tsx
+++ b/src/components/blog/BlogHeader.tsx
@@ -8,8 +8,8 @@ import { useState } from 'react';
 import LocaleSwitcher from '@/components/LocaleSwitcher';
 import { Link } from '@/libs/i18nNavigation';
 
-const HIDE_AFTER = 80;
-const SHADOW_AFTER = 8;
+const HIDE_AFTER = 120;
+const ELEVATE_AFTER = 8;
 
 const BlogHeader = () => {
   const t = useTranslations('Navbar');
@@ -22,43 +22,46 @@ const BlogHeader = () => {
     const previous = scrollY.getPrevious() ?? 0;
     const goingDown = latest > previous;
     setHidden(latest > HIDE_AFTER && goingDown);
-    setScrolled(latest > SHADOW_AFTER);
+    setScrolled(latest > ELEVATE_AFTER);
   });
 
   return (
     <motion.header
-      className={`sticky top-0 z-50 border-b transition-shadow duration-300 ${
-        scrolled ? 'border-neutral-200 bg-white/95 shadow-[0_1px_0_rgba(0,0,0,0.02)] backdrop-blur' : 'border-transparent bg-white'
+      className={`sticky top-0 z-50 transition-[background-color,border-color,backdrop-filter] duration-300 ${
+        scrolled
+          ? 'border-b border-stone-200/70 bg-stone-50/80 backdrop-blur-xl'
+          : 'border-b border-transparent bg-stone-50'
       }`}
       initial={{ y: -80, opacity: 0 }}
       animate={{ y: hidden ? -80 : 0, opacity: 1 }}
-      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+      transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
     >
-      <div className="mx-auto flex h-16 max-w-5xl items-center justify-between gap-6 px-4 sm:px-6">
-        <Link href="/" className="flex items-center gap-2.5">
+      <div className="mx-auto flex h-[72px] max-w-6xl items-center justify-between gap-6 px-5 sm:px-8">
+        <Link href="/" className="group flex items-center gap-2.5">
           <Image src="/assets/images/logo/logo_symbol_black.svg" alt="Agility" width={26} height={26} />
           <Image src="/assets/images/logo/logo_name_black.svg" alt="Agility" width={82} height={20} className="hidden sm:block" />
         </Link>
 
-        <nav className="flex items-center gap-1 sm:gap-2">
+        <nav className="flex items-center gap-1 sm:gap-1.5">
           <Link
             href="/blog"
-            className="rounded-full px-3 py-1.5 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900"
+            className="rounded-full px-3.5 py-2 text-[13px] font-medium tracking-tight text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
           >
             {tBlog('badge')}
           </Link>
           <Link
             href="/"
-            className="hidden rounded-full px-3 py-1.5 text-sm font-medium text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900 sm:inline-block"
+            className="hidden rounded-full px-3.5 py-2 text-[13px] font-medium tracking-tight text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900 sm:inline-block"
           >
             {t('home')}
           </Link>
           <LocaleSwitcher theme="light" className="ml-1" />
           <Link
             href="/#Contato"
-            className="ml-1 hidden rounded-full bg-neutral-900 px-4 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-neutral-700 sm:inline-block"
+            className="ml-1.5 hidden items-center gap-1.5 rounded-full bg-stone-900 px-4 py-2 text-[13px] font-medium tracking-tight text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all hover:bg-stone-800 hover:shadow-[0_4px_12px_rgba(0,0,0,0.12),inset_0_1px_0_rgba(255,255,255,0.08)] sm:inline-flex"
           >
             {t('cta')}
+            <span aria-hidden className="text-stone-400">→</span>
           </Link>
         </nav>
       </div>

--- a/src/components/blog/BlogHero.tsx
+++ b/src/components/blog/BlogHero.tsx
@@ -16,9 +16,9 @@ type BlogHeroProps = {
 };
 
 const SIZE_TO_TITLE = {
-  sm: 'text-2xl md:text-3xl',
-  md: 'text-3xl md:text-4xl lg:text-[2.75rem]',
-  lg: 'text-4xl md:text-5xl lg:text-[3.25rem]',
+  sm: 'text-3xl md:text-4xl',
+  md: 'text-4xl md:text-5xl lg:text-[3.5rem]',
+  lg: 'text-[2.5rem] leading-[1.05] md:text-6xl lg:text-[4.25rem]',
 } as const;
 
 const BlogHero = ({
@@ -33,49 +33,57 @@ const BlogHero = ({
   const isCenter = align === 'center';
 
   return (
-    <section className="border-b border-neutral-200/70 bg-white">
-      <div className={`mx-auto max-w-6xl px-4 pb-10 pt-14 sm:px-6 md:pb-14 md:pt-20 ${isCenter ? 'text-center' : 'text-left'}`}>
+    <section className="relative">
+      {/* Hairline divider — gradient fade for a more editorial finish than a flat border. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-stone-300/60 to-transparent"
+      />
+      <div className={`mx-auto max-w-6xl px-5 pb-14 pt-16 sm:px-8 md:pb-20 md:pt-28 ${isCenter ? 'text-center' : 'text-left'}`}>
         {breadcrumbs && breadcrumbs.length > 0 && (
           <nav
             aria-label="Breadcrumb"
-            className={`mb-6 flex flex-wrap items-center gap-1.5 text-xs text-neutral-500 ${isCenter ? 'justify-center' : ''}`}
+            className={`mb-8 flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.16em] text-stone-400 ${isCenter ? 'justify-center' : ''}`}
           >
             {breadcrumbs.map((crumb, index) => (
-              <div key={index} className="flex items-center gap-1.5">
+              <div key={index} className="flex items-center gap-2">
                 {crumb.href
                   ? (
-                      <Link href={crumb.href} className="transition-colors hover:text-neutral-900">
+                      <Link href={crumb.href} className="transition-colors hover:text-stone-900">
                         {crumb.label}
                       </Link>
                     )
                   : (
-                      <span className="text-neutral-700">{crumb.label}</span>
+                      <span className="text-stone-700">{crumb.label}</span>
                     )}
-                {index < breadcrumbs.length - 1 && <span className="text-neutral-300">/</span>}
+                {index < breadcrumbs.length - 1 && <span className="text-stone-300">/</span>}
               </div>
             ))}
           </nav>
         )}
 
-        <div className={isCenter ? 'mx-auto max-w-3xl' : 'max-w-3xl'}>
+        <div className={isCenter ? 'mx-auto max-w-3xl' : 'max-w-4xl'}>
           {eyebrow && (
-            <p className="mb-4 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-              {eyebrow}
-            </p>
+            <div className={`mb-6 flex items-center gap-3 ${isCenter ? 'justify-center' : ''}`}>
+              <span aria-hidden className="h-px w-8 bg-primary" />
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primary">
+                {eyebrow}
+              </p>
+            </div>
           )}
 
-          <h1 className={`font-bold leading-[1.1] tracking-tight text-neutral-900 ${SIZE_TO_TITLE[size]}`}>
+          <h1 className={`font-semibold tracking-[-0.02em] text-stone-900 ${SIZE_TO_TITLE[size]}`}>
             {title}
           </h1>
 
           {subtitle && (
-            <p className="mt-5 text-base leading-relaxed text-neutral-600 md:mt-6 md:text-lg">
+            <p className={`mt-6 text-lg leading-relaxed text-stone-500 md:mt-7 md:text-xl ${isCenter ? 'mx-auto max-w-2xl' : 'max-w-2xl'}`}>
               {subtitle}
             </p>
           )}
 
           {meta && (
-            <div className={`mt-7 flex flex-wrap items-center gap-3 text-sm text-neutral-500 ${isCenter ? 'justify-center' : ''}`}>
+            <div className={`mt-9 flex flex-wrap items-center gap-3 text-sm text-stone-500 ${isCenter ? 'justify-center' : ''}`}>
               {meta}
             </div>
           )}

--- a/src/components/blog/BlogIndex.tsx
+++ b/src/components/blog/BlogIndex.tsx
@@ -12,6 +12,7 @@ type BlogIndexProps = {
   allLabel: string;
   readArticleLabel: string;
   emptyLabel: string;
+  moreLabel?: string;
 };
 
 const BlogIndex = ({
@@ -22,11 +23,12 @@ const BlogIndex = ({
   allLabel,
   readArticleLabel,
   emptyLabel,
+  moreLabel,
 }: BlogIndexProps) => {
   const [featured, ...rest] = items;
 
   return (
-    <section className="mx-auto max-w-6xl px-4 pb-24 pt-4 sm:px-6 md:pb-32 md:pt-6">
+    <section className="mx-auto max-w-6xl px-5 pb-28 pt-2 sm:px-8 md:pb-36 md:pt-4">
       <BlogCategoryTabs
         categories={categories}
         activeSlug={activeSlug}
@@ -34,13 +36,13 @@ const BlogIndex = ({
       />
 
       {!featured && (
-        <p className="mt-12 rounded-xl border border-dashed border-neutral-200 bg-neutral-50 px-6 py-16 text-center text-sm text-neutral-500">
+        <p className="mt-16 rounded-2xl border border-dashed border-stone-200 bg-white/40 px-6 py-20 text-center text-sm text-stone-500">
           {emptyLabel}
         </p>
       )}
 
       {featured && (
-        <div className="mt-8 md:mt-10">
+        <div className="mt-10 md:mt-12">
           <BlogFeaturedCard
             item={featured}
             locale={locale}
@@ -50,10 +52,20 @@ const BlogIndex = ({
       )}
 
       {rest.length > 0 && (
-        <div className="mt-8 grid grid-cols-1 gap-5 md:mt-10 md:grid-cols-2 lg:grid-cols-3">
-          {rest.map(item => (
-            <BlogCard key={item.slug} item={item} locale={locale} />
-          ))}
+        <div className="mt-16 md:mt-20">
+          {moreLabel && (
+            <div className="mb-8 flex items-center gap-4">
+              <span aria-hidden className="h-px w-10 bg-stone-300" />
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
+                {moreLabel}
+              </p>
+            </div>
+          )}
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {rest.map(item => (
+              <BlogCard key={item.slug} item={item} locale={locale} />
+            ))}
+          </div>
         </div>
       )}
     </section>

--- a/src/data/blog.json
+++ b/src/data/blog.json
@@ -66,7 +66,8 @@
         "type": "paragraph",
         "text": "Por fim, peça referências e ligue para elas. Conversar 15 minutos com um cliente atual diz mais do que qualquer apresentação comercial."
       }
-    ]
+    ],
+    "status": "published"
   },
   {
     "slug": "mvp-em-30-dias-o-que-cabe-e-o-que-nao-cabe",
@@ -124,7 +125,8 @@
         "type": "paragraph",
         "text": "Se a equipe estiver tentada a adicionar tudo isso \"porque é simples\", lembre que cada feature opcional é um vetor de bug, manutenção e distração até o lançamento."
       }
-    ]
+    ],
+    "status": "published"
   },
   {
     "slug": "design-system-para-times-pequenos",
@@ -178,6 +180,7 @@
         "type": "paragraph",
         "text": "Esses quatro respondem por 70% das telas em produtos B2B. Resolvendo bem, o resto do design system pode crescer organicamente."
       }
-    ]
+    ],
+    "status": "published"
   }
 ]

--- a/src/libs/blogStore.ts
+++ b/src/libs/blogStore.ts
@@ -1,0 +1,74 @@
+import { eq } from 'drizzle-orm';
+
+import seedData from '@/data/blog.json';
+import { db } from '@/libs/DB';
+import { blogStoreSchema } from '@/models/Schema';
+import type { BlogPost } from '@/types/blog';
+
+/**
+ * Armazenamento dos posts do blog.
+ *
+ * Antes os posts viviam em src/data/blog.json e a API escrevia nesse arquivo —
+ * o que falha em runtime serverless (filesystem read-only → storage_write_failed).
+ * Agora a fonte de verdade é o Postgres (via Drizzle, ver src/libs/DB): uma única
+ * linha JSONB (id = 1) com o array inteiro de posts. A API é single-writer.
+ *
+ * O blog.json continua existindo como SEED: na primeira leitura, se a tabela
+ * estiver vazia, ela é populada com o snapshot do build. Também serve de fallback
+ * de leitura quando o banco está indisponível (ver getPostsSafe).
+ */
+
+const SINGLETON_ID = 1;
+
+const seedPosts = (): BlogPost[] => seedData as BlogPost[];
+
+/**
+ * Leitura estrita: lança em caso de falha do banco. Use na API (POST /api/blog),
+ * onde uma falha de leitura deve virar 500 storage_read_failed.
+ */
+export const getPosts = async (): Promise<BlogPost[]> => {
+  const rows = await db
+    .select({ data: blogStoreSchema.data })
+    .from(blogStoreSchema)
+    .where(eq(blogStoreSchema.id, SINGLETON_ID))
+    .limit(1);
+
+  if (rows.length > 0) {
+    return rows[0]!.data;
+  }
+
+  // Tabela vazia: semeia uma vez com o snapshot do build.
+  const seed = seedPosts();
+  await db
+    .insert(blogStoreSchema)
+    .values({ id: SINGLETON_ID, data: seed })
+    .onConflictDoNothing();
+  return seed;
+};
+
+/**
+ * Leitura tolerante: nunca lança — em falha, devolve o snapshot do build.
+ * Use nas páginas/sitemap, para o site não cair se o banco estiver fora do ar.
+ */
+export const getPostsSafe = async (): Promise<BlogPost[]> => {
+  try {
+    return await getPosts();
+  } catch (err) {
+    console.error('[blogStore] leitura falhou, usando snapshot do build:', err);
+    return seedPosts();
+  }
+};
+
+/**
+ * Persiste o array inteiro de posts (upsert na linha singleton). Lança em caso de
+ * falha (a API converte para 500 storage_write_failed).
+ */
+export const savePosts = async (posts: BlogPost[]): Promise<void> => {
+  await db
+    .insert(blogStoreSchema)
+    .values({ id: SINGLETON_ID, data: posts })
+    .onConflictDoUpdate({
+      target: blogStoreSchema.id,
+      set: { data: posts },
+    });
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -199,6 +199,7 @@
     "readingTimeSuffix": "min read",
     "allLabel": "All",
     "readArticle": "Read article",
+    "more": "More articles",
     "empty": "No posts in this category yet — come back soon."
   },
   "BlogCategory": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -199,6 +199,7 @@
     "readingTimeSuffix": "min de leitura",
     "allLabel": "Todos",
     "readArticle": "Leia o artigo",
+    "more": "Mais artigos",
     "empty": "Ainda não temos posts nessa categoria — volte em breve."
   },
   "BlogCategory": {

--- a/src/models/Schema.ts
+++ b/src/models/Schema.ts
@@ -1,4 +1,6 @@
-import { pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+import { integer, jsonb, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+
+import type { BlogPost } from '@/types/blog';
 
 export const guestbookSchema = pgTable('guestbook', {
   id: serial('id').primaryKey(),
@@ -9,4 +11,15 @@ export const guestbookSchema = pgTable('guestbook', {
     .$onUpdate(() => new Date())
     .notNull(),
   createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),
+});
+
+// Posts do blog em uma única linha (id = 1) com o array inteiro em JSONB.
+// A API é single-writer, então não precisamos de uma tabela normalizada.
+export const blogStoreSchema = pgTable('blog_store', {
+  id: integer('id').primaryKey().default(1),
+  data: jsonb('data').$type<BlogPost[]>().notNull(),
+  updatedAt: timestamp('updated_at', { mode: 'date' })
+    .defaultNow()
+    .$onUpdate(() => new Date())
+    .notNull(),
 });

--- a/src/templates/BlogTemplate.tsx
+++ b/src/templates/BlogTemplate.tsx
@@ -10,16 +10,26 @@ const BlogTemplate = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname();
 
   return (
-    <div className="flex min-h-screen flex-col bg-white font-poppins text-neutral-900 antialiased">
+    <div className="flex min-h-screen flex-col bg-stone-50 font-poppins text-stone-900 antialiased selection:bg-stone-900 selection:text-stone-50">
+      {/* Subtle grain overlay — barely perceptible, kills the flatness of pure off-white. */}
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-0 opacity-[0.025] mix-blend-multiply"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle at 1px 1px, rgba(0,0,0,0.7) 1px, transparent 0)',
+          backgroundSize: '3px 3px',
+        }}
+      />
       <BlogHeader />
       <AnimatePresence mode="wait">
         <motion.main
           key={pathname}
-          className="flex-1"
+          className="relative z-[1] flex-1"
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -8 }}
-          transition={{ duration: 0.3, ease: 'easeInOut' as const }}
+          transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
         >
           {children}
         </motion.main>

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -12,6 +12,11 @@ export type BlogBodyBlock
     | { type: 'image'; src: string; alt: string; caption?: string }
     | { type: 'code'; language?: string; code: string };
 
+// Drafts are invisible to public surfaces (listing, detail page, sitemap,
+// generateStaticParams). A missing status means "published" — legacy posts
+// from before this field was introduced are grandfathered.
+export type BlogStatus = 'draft' | 'published';
+
 export type BlogPost = {
   slug: string;
   title: string;
@@ -24,5 +29,9 @@ export type BlogPost = {
   category?: string;
   tags?: string[];
   author?: BlogAuthor;
+  status?: BlogStatus;
   body: BlogBodyBlock[];
 };
+
+export const isPublished = (post: Pick<BlogPost, 'status'>): boolean =>
+  post.status !== 'draft';


### PR DESCRIPTION
## What & why
Bundles three concerns that ship together because they all touch the blog surface:

1. **Storage migration (filesystem → Postgres)** — fixes `HTTP 500 storage_write_failed` on Vercel. Posts now live in a Drizzle-backed `blog_store` JSONB row, with `src/data/blog.json` serving as both seed and graceful fallback. Details in `STORAGE-FIX.md`.
2. **New API actions** for the AI agent: `publish`, `unpublish`, `delete`, plus `status: 'draft' | 'published'` on `create`/`update` (defaults to `'published'` — backward-compatible). Drafts are 404'd on the public detail page, hidden from listing/category/sitemap. New `POST /api/blog/upload` for base64 image uploads to `public/blog/uploads/` (content-addressed, idempotent — flagged as still filesystem-backed in the docs).
3. **UI polish** — warmer `stone` palette, larger editorial typography, refined hover states on cards (lift + multi-stop shadow), gradient hairline dividers, 3-column footer, refined article prose with lede emphasis, magazine-style pull quotes, uppercase tags. Goal: high-ticket editorial feel without losing the clean baseline.

Includes the bot infrastructure scaffolding (`bot/` — runs under launchd, eslint-ignored) and the Drizzle migration (`migrations/0001_handy_vampiro.sql`) that adds the `blog_store` table on first boot via `migratePg`.

## Required before merging
- [ ] **Provision Postgres** for production (Neon free tier or Vercel Postgres) — see `STORAGE-FIX.md` §1.
- [ ] **Set `DATABASE_URL`** in Vercel → Project → Settings → Environment Variables.
- [ ] Confirm `BLOG_API_TOKEN` is already set in Vercel (the bot/.secret-token mirrors this).

On first request after deploy, `blog_store` is auto-seeded from `src/data/blog.json` (3 posts preserved).

## Test plan
- [x] `npm install` — clean
- [x] `npm run check-types` — clean
- [x] `npm run lint` — clean (with new `bot/**/*` ignore for the standalone Node runtime)
- [x] `npm run test` — **141/141 passing across 25 files**, including 24 new tests for status filtering, publish/unpublish, delete, upload validation/idempotency, storage errors
- [x] `npm run db:generate` produces a clean `0001_handy_vampiro.sql` creating `blog_store`
- [x] Dev server smoke: list / read / create-as-draft / publish / unpublish / delete / image upload all return expected status codes; draft slug → 404, post-publish → 200
- [ ] **Post-deploy**: run `action: "list"` (expect 200) then `action: "create"` (expect 201) against `agilitycreative.com/api/blog` to confirm writes persist

## Notes
- Direct push to `main` is protected — this PR is the path.
- `STORAGE-FIX.md`, `CLAUDE.md`, and `PLANO-bot-blog-tech.md` are committed alongside the code so future-you (and the bot) have the runbook in-repo.
- `bot/` runtime artifacts (`bot/queue/*.json`, `bot/published/`, `bot/failed/`, `bot/*.log`, `bot/.secret-token`) are gitignored.