### PR TITLE
feat(blog): rss feed + double-opt-in email subscribers with publish fan-out

### DIFF
--- a/migrations/0002_natural_nehzno.sql
+++ b/migrations/0002_natural_nehzno.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "blog_subscribers" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"email" varchar(320) NOT NULL,
+	"status" varchar(16) DEFAULT 'pending' NOT NULL,
+	"confirm_token" varchar(64) NOT NULL,
+	"unsubscribe_token" varchar(64) NOT NULL,
+	"locale" varchar(8) DEFAULT 'pt-BR' NOT NULL,
+	"source" varchar(64),
+	"confirmed_at" timestamp,
+	"unsubscribed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "blog_subscribers_email_idx" ON "blog_subscribers" USING btree ("email");--> statement-breakpoint
+CREATE UNIQUE INDEX "blog_subscribers_confirm_token_idx" ON "blog_subscribers" USING btree ("confirm_token");--> statement-breakpoint
+CREATE UNIQUE INDEX "blog_subscribers_unsubscribe_token_idx" ON "blog_subscribers" USING btree ("unsubscribe_token");--> statement-breakpoint
+CREATE INDEX "blog_subscribers_status_idx" ON "blog_subscribers" USING btree ("status");

--- a/migrations/meta/0002_snapshot.json
+++ b/migrations/meta/0002_snapshot.json
@@ -1,0 +1,241 @@
+{
+  "id": "0f58b7c2-246d-419a-ac29-87d2ebbd4ff7",
+  "prevId": "d88be45f-3ec4-4caf-83b9-33c4a35015f1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_store": {
+      "name": "blog_store",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_subscribers": {
+      "name": "blog_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "confirm_token": {
+          "name": "confirm_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsubscribe_token": {
+          "name": "unsubscribe_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pt-BR'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blog_subscribers_email_idx": {
+          "name": "blog_subscribers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_subscribers_confirm_token_idx": {
+          "name": "blog_subscribers_confirm_token_idx",
+          "columns": [
+            {
+              "expression": "confirm_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_subscribers_unsubscribe_token_idx": {
+          "name": "blog_subscribers_unsubscribe_token_idx",
+          "columns": [
+            {
+              "expression": "unsubscribe_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blog_subscribers_status_idx": {
+          "name": "blog_subscribers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guestbook": {
+      "name": "guestbook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780691119589,
       "tag": "0001_handy_vampiro",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780791420892,
+      "tag": "0002_natural_nehzno",
+      "breakpoints": true
     }
   ]
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,7 +33,14 @@ const nextConfig = {
   async rewrites() {
     return {
       beforeFiles: [
+        // /sitemap.xml → custom route (lets us inject the XSL stylesheet
+        // directive; the MetadataRoute.Sitemap convention doesn't support it).
         { source: '/sitemap.xml', destination: '/sitemap-feed' },
+        // /feed.xml + /rss.xml → the RSS route. Same rewrite reason as above
+        // and gives subscribers two URLs that work (some readers default to
+        // /rss.xml, others to /feed.xml).
+        { source: '/feed.xml', destination: '/feed-rss' },
+        { source: '/rss.xml', destination: '/feed-rss' },
       ],
       afterFiles: [],
       fallback: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-dom": "19.2.6",
         "react-hook-form": "^7.52.2",
         "react-icons": "^5.3.0",
+        "resend": "^6.12.4",
         "sharp": "^0.33.5",
         "tailwind-merge": "3.6.0",
         "zod": "4.4.3"
@@ -26894,6 +26895,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -28344,6 +28351,27 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-dom": "19.2.6",
     "react-hook-form": "^7.52.2",
     "react-icons": "^5.3.0",
+    "resend": "^6.12.4",
     "sharp": "^0.33.5",
     "tailwind-merge": "3.6.0",
     "zod": "4.4.3"

--- a/public/feed.xsl
+++ b/public/feed.xsl
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:media="http://search.yahoo.com/mrss/">
+  <xsl:output method="html" version="5.0" encoding="UTF-8" indent="yes" omit-xml-declaration="yes" />
+  <xsl:template match="/">
+    <html lang="pt-BR">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex" />
+        <title><xsl:value-of select="rss/channel/title" /> — RSS</title>
+        <style>
+          :root {
+            --bg: #fafaf9;
+            --surface: #ffffff;
+            --border: rgba(0, 0, 0, 0.06);
+            --border-strong: rgba(0, 0, 0, 0.12);
+            --text: #1c1917;
+            --text-muted: #78716c;
+            --text-dim: #a8a29e;
+            --accent: #fd512e;
+          }
+          * { box-sizing: border-box; }
+          html, body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, "Helvetica Neue", Arial, sans-serif;
+            font-size: 15px;
+            line-height: 1.6;
+            -webkit-font-smoothing: antialiased;
+          }
+          .wrap { max-width: 760px; margin: 0 auto; padding: 56px 24px 96px; }
+          header { padding-bottom: 32px; border-bottom: 1px solid var(--border); margin-bottom: 36px; }
+          .eyebrow {
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.22em;
+            text-transform: uppercase;
+            color: var(--accent);
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            margin: 0 0 16px;
+          }
+          .eyebrow::before {
+            content: "";
+            display: inline-block;
+            width: 32px;
+            height: 1px;
+            background: var(--accent);
+          }
+          h1 {
+            font-size: 38px;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            margin: 0;
+            line-height: 1.1;
+          }
+          p.lede {
+            color: var(--text-muted);
+            margin: 16px 0 0;
+            font-size: 17px;
+            line-height: 1.55;
+          }
+          .actions { display: flex; gap: 12px; flex-wrap: wrap; margin: 28px 0 0; }
+          .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 16px;
+            border-radius: 999px;
+            font-size: 13px;
+            font-weight: 500;
+            text-decoration: none;
+            transition: all .2s ease;
+          }
+          .btn-primary {
+            background: #1c1917;
+            color: #fafaf9;
+            box-shadow: 0 1px 2px rgba(0,0,0,.08), inset 0 1px 0 rgba(255,255,255,.08);
+          }
+          .btn-primary:hover { background: #292524; }
+          .btn-ghost {
+            background: transparent;
+            color: var(--text-muted);
+            border: 1px solid var(--border-strong);
+          }
+          .btn-ghost:hover { color: var(--text); border-color: var(--text); }
+          .url-row {
+            margin-top: 28px;
+            padding: 14px 16px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            flex-wrap: wrap;
+          }
+          .url-row code {
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-size: 13px;
+            color: var(--text);
+            word-break: break-all;
+          }
+          .url-row .label {
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            color: var(--text-dim);
+          }
+          .items { list-style: none; padding: 0; margin: 0; display: grid; gap: 12px; }
+          .item {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            padding: 22px 24px;
+            transition: all .25s ease;
+          }
+          .item:hover {
+            border-color: var(--border-strong);
+            box-shadow: 0 12px 28px -16px rgba(0,0,0,.12);
+            transform: translateY(-1px);
+          }
+          .item .meta {
+            display: flex;
+            gap: 10px;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: var(--text-dim);
+            margin-bottom: 10px;
+            align-items: center;
+          }
+          .item .meta .cat { color: var(--accent); }
+          .item .meta .dot {
+            width: 4px; height: 4px; border-radius: 50%;
+            background: var(--border-strong);
+          }
+          .item h2 {
+            margin: 0 0 6px;
+            font-size: 19px;
+            font-weight: 600;
+            letter-spacing: -0.01em;
+            line-height: 1.3;
+          }
+          .item h2 a {
+            color: var(--text);
+            text-decoration: none;
+          }
+          .item h2 a:hover { color: var(--accent); }
+          .item .desc {
+            color: var(--text-muted);
+            margin: 0;
+            font-size: 14px;
+            line-height: 1.55;
+          }
+          footer {
+            margin-top: 40px;
+            color: var(--text-dim);
+            font-size: 12px;
+            display: flex;
+            justify-content: space-between;
+            gap: 16px;
+            flex-wrap: wrap;
+          }
+          footer a { color: inherit; text-decoration: underline; text-decoration-color: var(--border-strong); }
+        </style>
+      </head>
+      <body>
+        <main class="wrap">
+          <header>
+            <p class="eyebrow">RSS Feed</p>
+            <h1><xsl:value-of select="rss/channel/title" /></h1>
+            <p class="lede"><xsl:value-of select="rss/channel/description" /></p>
+            <div class="url-row">
+              <span class="label">URL do feed</span>
+              <code><xsl:value-of select="rss/channel/atom:link/@href" /></code>
+            </div>
+            <div class="actions">
+              <a class="btn btn-primary">
+                <xsl:attribute name="href">feed://<xsl:value-of select="substring-after(rss/channel/atom:link/@href, '://')" /></xsl:attribute>
+                Inscrever no leitor RSS
+              </a>
+              <a class="btn btn-ghost" target="_blank" rel="noopener">
+                <xsl:attribute name="href">https://feedly.com/i/subscription/feed/<xsl:value-of select="rss/channel/atom:link/@href" /></xsl:attribute>
+                Adicionar ao Feedly
+              </a>
+              <a class="btn btn-ghost">
+                <xsl:attribute name="href"><xsl:value-of select="rss/channel/link" /></xsl:attribute>
+                Voltar ao blog
+              </a>
+            </div>
+          </header>
+
+          <ul class="items">
+            <xsl:for-each select="rss/channel/item">
+              <li class="item">
+                <div class="meta">
+                  <span><xsl:value-of select="substring(pubDate, 6, 11)" /></span>
+                  <xsl:if test="category">
+                    <span class="dot"></span>
+                    <span class="cat"><xsl:value-of select="category" /></span>
+                  </xsl:if>
+                </div>
+                <h2>
+                  <a>
+                    <xsl:attribute name="href"><xsl:value-of select="link" /></xsl:attribute>
+                    <xsl:value-of select="title" />
+                  </a>
+                </h2>
+                <p class="desc"><xsl:value-of select="description" /></p>
+              </li>
+            </xsl:for-each>
+          </ul>
+
+          <footer>
+            <span>Agility Creative · <a href="/blog">/blog</a></span>
+            <span>Spec: <a href="https://www.rssboard.org/rss-specification" rel="noopener">RSS 2.0</a></span>
+          </footer>
+        </main>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(props: {
   const { slug } = await props.params;
   const posts = await getPostsSafe();
   const post = posts.find(item => item.slug === slug);
-  const alternates = buildDefaultLocaleAlternates(`/blog/${slug}`);
+  const alternates = buildDefaultLocaleAlternates(`/blog/${slug}`, { withRssFeed: true });
   const title = post?.title ?? slug;
   const description = post?.excerpt ?? '';
   const ogImage = post?.coverImage;

--- a/src/app/[locale]/blog/category/[slug]/page.tsx
+++ b/src/app/[locale]/blog/category/[slug]/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata(props: {
   const posts = await getPostsSafe();
   const category = findCategoryBySlug(posts, slug);
   const t = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
-  const alternates = buildDefaultLocaleAlternates(`/blog/category/${slug}`);
+  const alternates = buildDefaultLocaleAlternates(`/blog/category/${slug}`, { withRssFeed: true });
 
   if (!category) {
     return {

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
 import type { BlogCardItem } from '@/components/blog';
-import { BlogHero, BlogIndex, getOrderedCategories } from '@/components/blog';
+import { BlogHero, BlogIndex, getOrderedCategories, SubscribeForm } from '@/components/blog';
 import { getPostsSafe } from '@/libs/blogStore';
 import { isPublished } from '@/types/blog';
 import { AppConfig } from '@/utils/AppConfig';
@@ -19,7 +19,7 @@ export async function generateMetadata(): Promise<Metadata> {
   // → /blog, but generateMetadata can still be called once before the redirect
   // is followed).
   const t = await getTranslations({ locale: AppConfig.defaultLocale, namespace: 'BlogPage' });
-  const alternates = buildDefaultLocaleAlternates(BLOG_PATH);
+  const alternates = buildDefaultLocaleAlternates(BLOG_PATH, { withRssFeed: true });
   const title = `${t('titlePrefix')} ${t('titleHighlight')}`.trim();
 
   return {
@@ -110,6 +110,10 @@ const BlogPage = async () => {
         emptyLabel={t('empty')}
         moreLabel={t('more')}
       />
+
+      <div className="px-5 sm:px-8">
+        <SubscribeForm source="blog-index" />
+      </div>
 
       <script
         type="application/ld+json"

--- a/src/app/api/blog/confirm/route.ts
+++ b/src/app/api/blog/confirm/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+
+import { confirmByToken } from '@/libs/subscribers';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// GET /api/blog/confirm?token=<hex> — the user clicks this from their inbox.
+// We render minimal inline HTML rather than redirecting to a route so the
+// success message is rendered even if the destination is rate-limited or down.
+
+const renderPage = (kind: 'confirmed' | 'invalid'): Response => {
+  const isConfirmed = kind === 'confirmed';
+  const title = isConfirmed
+    ? 'Inscrição confirmada'
+    : 'Link inválido ou expirado';
+  const heading = isConfirmed
+    ? 'Tudo certo. Você está dentro.'
+    : 'Esse link não funciona mais';
+  const body = isConfirmed
+    ? 'Você vai receber um e-mail toda vez que publicarmos um artigo novo. Pode esperar leituras curtas, na maioria das vezes em pt-BR, sobre tecnologia, IA e produto.'
+    : 'O link pode ter expirado depois que você pediu uma nova confirmação, ou pode ter sido digitado errado. Tente assinar de novo no blog.';
+  const ctaHref = '/blog';
+  const ctaLabel = isConfirmed ? 'Ir para o blog' : 'Voltar para o blog';
+
+  const html = `<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
+  <title>${title} — Agility Creative</title>
+  <style>
+    :root { color-scheme: light; }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; background: #fafaf9; color: #1c1917; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, "Helvetica Neue", Arial, sans-serif; }
+    .wrap { max-width: 480px; margin: 0 auto; padding: 80px 24px 64px; }
+    .eyebrow { font-size: 11px; font-weight: 600; letter-spacing: 0.22em; text-transform: uppercase; color: #FD512E; display: inline-flex; gap: 12px; align-items: center; margin: 0 0 20px; }
+    .eyebrow::before { content: ""; width: 32px; height: 1px; background: #FD512E; display: inline-block; }
+    h1 { margin: 0 0 16px; font-size: 32px; line-height: 1.15; letter-spacing: -0.02em; font-weight: 600; }
+    p.lede { margin: 0 0 32px; color: #57534e; line-height: 1.6; font-size: 16px; }
+    .cta { display: inline-flex; align-items: center; gap: 8px; padding: 12px 20px; border-radius: 999px; background: #1c1917; color: #fafaf9; text-decoration: none; font-weight: 500; font-size: 14px; }
+    .cta:hover { background: #292524; }
+    footer { margin-top: 48px; color: #a8a29e; font-size: 12px; }
+    footer a { color: inherit; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <p class="eyebrow">${isConfirmed ? 'Inscrição confirmada' : 'Algo deu errado'}</p>
+    <h1>${heading}</h1>
+    <p class="lede">${body}</p>
+    <a class="cta" href="${ctaHref}">${ctaLabel} →</a>
+    <footer>
+      <p>Agility Creative · <a href="/">agilitycreative.com</a></p>
+    </footer>
+  </main>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: isConfirmed ? 200 : 400,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'private, no-store',
+    },
+  });
+};
+
+export async function GET(req: Request) {
+  const token = new URL(req.url).searchParams.get('token') ?? '';
+  const result = await confirmByToken(token);
+  return renderPage(result.ok ? 'confirmed' : 'invalid');
+}

--- a/src/app/api/blog/route.test.ts
+++ b/src/app/api/blog/route.test.ts
@@ -11,6 +11,13 @@ vi.mock('@/libs/blogStore', () => ({
   savePosts: vi.fn(),
 }));
 
+// Stub the notification fan-out — the route fires it asynchronously on
+// publish, but the test environment doesn't have RESEND_API_KEY or DB access.
+vi.mock('@/libs/email/notifyNewPost', () => ({
+  fireNewPostNotification: vi.fn(),
+  notifyNewPost: vi.fn(),
+}));
+
 const TOKEN = '11111111111111111111111111111111';
 
 const samplePosts = (): BlogPost[] => [

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { slugifyCategory } from '@/components/blog/categories';
 import { getPosts, savePosts } from '@/libs/blogStore';
+import { fireNewPostNotification } from '@/libs/email/notifyNewPost';
 import type { BlogBodyBlock, BlogPost, BlogStatus } from '@/types/blog';
 
 import { isAuthorized } from './auth';
@@ -305,6 +306,9 @@ export async function POST(req: Request) {
       } catch {
         return errorResponse(500, 'storage_write_failed');
       }
+      // Notify confirmed subscribers when a post is born as published.
+      // Drafts never trigger this — the agent gets a chance to review first.
+      fireNewPostNotification(newPost);
       return NextResponse.json({ ok: true, data: { post: newPost } }, { status: 201 });
     }
 
@@ -334,6 +338,14 @@ export async function POST(req: Request) {
       } catch {
         return errorResponse(500, 'storage_write_failed');
       }
+      // Fire-on-transition: notify only when the patch actually moves the
+      // post from draft → published (a status-less patch or a published →
+      // published edit is intentionally silent so updates don't spam).
+      const wasDraft = effectiveStatus(current) === 'draft';
+      const isNowPublished = effectiveStatus(merged) === 'published';
+      if (wasDraft && isNowPublished) {
+        fireNewPostNotification(merged);
+      }
       return NextResponse.json({ ok: true, data: { post: merged } });
     }
 
@@ -346,6 +358,11 @@ export async function POST(req: Request) {
           return errorResponse(404, 'not_found', { slug: command.slug });
         }
         return errorResponse(500, result.error);
+      }
+      // Only notify on a real transition draft → published; an idempotent
+      // re-publish (changed=false) is silent.
+      if (command.action === 'publish' && result.changed) {
+        fireNewPostNotification(result.post);
       }
       return NextResponse.json({
         ok: true,

--- a/src/app/api/blog/subscribe/route.ts
+++ b/src/app/api/blog/subscribe/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { EMAIL_CONFIG } from '@/libs/email/config';
+import { sendEmail } from '@/libs/email/sender';
+import { buildConfirmEmail } from '@/libs/email/templates/confirm';
+import { subscribe } from '@/libs/subscribers';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// Public endpoint — no bearer auth (it's hit by the public subscribe form).
+// We still validate aggressively and respond with consistent shapes so a
+// curious script can't enumerate which emails are already subscribed.
+
+const requestSchema = z.object({
+  email: z.string().email().max(320),
+  // Free-form source label (e.g. 'blog-footer', 'post:slug') — used later for
+  // attribution. Bounded to keep adversarial input out of the DB.
+  source: z.string().min(1).max(64).optional(),
+  locale: z.string().min(2).max(8).optional(),
+});
+
+const errorResponse = (status: number, error: string) =>
+  NextResponse.json({ ok: false, error }, { status });
+
+const buildConfirmUrl = (token: string) =>
+  `${EMAIL_CONFIG.baseUrl}/api/blog/confirm?token=${encodeURIComponent(token)}`;
+
+export async function POST(req: Request) {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return errorResponse(400, 'invalid_json');
+  }
+  const parsed = requestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return errorResponse(400, 'invalid_request');
+  }
+
+  try {
+    const result = await subscribe(parsed.data.email, {
+      source: parsed.data.source,
+      locale: parsed.data.locale,
+    });
+
+    if (result.kind === 'already_confirmed') {
+      // Same generic "check your inbox" wording as the other branches so an
+      // attacker can't probe for existing subscribers via response timing or
+      // message contents.
+      return NextResponse.json({ ok: true, status: 'pending' });
+    }
+
+    const confirmUrl = buildConfirmUrl(result.subscriber.confirmToken);
+    const { subject, html, text } = buildConfirmEmail({ confirmUrl });
+
+    // Send + ignore non-fatal errors (e.g. Resend rate-limited a duplicate
+    // retry). The row exists either way — the user can re-request later.
+    await sendEmail({
+      to: result.subscriber.email,
+      subject,
+      html,
+      text,
+      headers: {
+        // Auto-reply suppression so this confirmation doesn't bounce off
+        // out-of-office responders.
+        'Auto-Submitted': 'auto-generated',
+      },
+    });
+    return NextResponse.json({ ok: true, status: 'pending' });
+  } catch (err) {
+    console.error('[subscribe] failed', err);
+    return errorResponse(500, 'storage_write_failed');
+  }
+}

--- a/src/app/api/blog/unsubscribe/route.ts
+++ b/src/app/api/blog/unsubscribe/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+
+import { unsubscribeByToken } from '@/libs/subscribers';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+// Two-way unsubscribe — GET for the one-click link in every email, POST for
+// the RFC 8058 `List-Unsubscribe=One-Click` header Gmail/Apple Mail honor.
+// Both honor the token immediately without an interstitial click; the page
+// the user lands on is just a confirmation render.
+
+const renderPage = (kind: 'unsubscribed' | 'invalid'): Response => {
+  const isOk = kind === 'unsubscribed';
+  const title = isOk ? 'Inscrição cancelada' : 'Link inválido';
+  const heading = isOk
+    ? 'Pronto, removemos seu e-mail'
+    : 'Esse link não funciona mais';
+  const body = isOk
+    ? 'Você não vai receber mais e-mails nossos a partir de agora. Se mudou de ideia, é só assinar de novo no blog quando quiser.'
+    : 'O link pode ter expirado ou sido digitado errado. Se você ainda quer parar de receber, abra um e-mail nosso recente e use o link de "Cancelar inscrição" no rodapé.';
+
+  const html = `<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex" />
+  <title>${title} — Agility Creative</title>
+  <style>
+    :root { color-scheme: light; }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; background: #fafaf9; color: #1c1917; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, "Helvetica Neue", Arial, sans-serif; }
+    .wrap { max-width: 480px; margin: 0 auto; padding: 80px 24px 64px; }
+    .eyebrow { font-size: 11px; font-weight: 600; letter-spacing: 0.22em; text-transform: uppercase; color: #78716c; display: inline-flex; gap: 12px; align-items: center; margin: 0 0 20px; }
+    .eyebrow::before { content: ""; width: 32px; height: 1px; background: #a8a29e; display: inline-block; }
+    h1 { margin: 0 0 16px; font-size: 32px; line-height: 1.15; letter-spacing: -0.02em; font-weight: 600; }
+    p.lede { margin: 0 0 32px; color: #57534e; line-height: 1.6; font-size: 16px; }
+    .cta { display: inline-flex; align-items: center; gap: 8px; padding: 12px 20px; border-radius: 999px; background: #1c1917; color: #fafaf9; text-decoration: none; font-weight: 500; font-size: 14px; }
+    footer { margin-top: 48px; color: #a8a29e; font-size: 12px; }
+    footer a { color: inherit; text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <p class="eyebrow">${isOk ? 'Inscrição cancelada' : 'Algo deu errado'}</p>
+    <h1>${heading}</h1>
+    <p class="lede">${body}</p>
+    <a class="cta" href="/blog">Voltar para o blog →</a>
+    <footer>
+      <p>Agility Creative · <a href="/">agilitycreative.com</a></p>
+    </footer>
+  </main>
+</body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: isOk ? 200 : 400,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'private, no-store',
+    },
+  });
+};
+
+export async function GET(req: Request) {
+  const token = new URL(req.url).searchParams.get('token') ?? '';
+  const result = await unsubscribeByToken(token);
+  return renderPage(result.ok ? 'unsubscribed' : 'invalid');
+}
+
+// RFC 8058 one-click POST — Gmail and Apple Mail fire this when the user hits
+// the "Unsubscribe" button in their inbox UI. No HTML response needed; the
+// mail client only checks the HTTP status.
+export async function POST(req: Request) {
+  const token = new URL(req.url).searchParams.get('token') ?? '';
+  const result = await unsubscribeByToken(token);
+  if (!result.ok) {
+    return new NextResponse('invalid_token', { status: 400 });
+  }
+  return new NextResponse(null, { status: 200 });
+}

--- a/src/app/feed-rss/route.ts
+++ b/src/app/feed-rss/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server';
+
+import { getPostsSafe } from '@/libs/blogStore';
+import type { BlogBodyBlock, BlogPost } from '@/types/blog';
+import { isPublished } from '@/types/blog';
+import { AppConfig } from '@/utils/AppConfig';
+import { getBaseUrl } from '@/utils/Helpers';
+import { localizedUrl } from '@/utils/seo';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const FEED_TITLE = 'Agility Creative — Blog';
+const FEED_DESCRIPTION
+  = 'Tecnologia, IA e ideias que importam — novidades, tutoriais e bastidores do time da Agility, em pt-BR.';
+
+// XML escape helper — RSS bodies survive nesting so we have to be defensive.
+const xmlEscape = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+// Convert the structured body blocks into reasonable HTML for content:encoded.
+// We never trust user input here — readers like Feedly and Inoreader will
+// sanitize — but we still produce conservative markup.
+const renderBlockToHtml = (block: BlogBodyBlock): string => {
+  switch (block.type) {
+    case 'paragraph':
+      return `<p>${xmlEscape(block.text)}</p>`;
+    case 'heading': {
+      const tag = block.level === 3 ? 'h3' : 'h2';
+      return `<${tag}>${xmlEscape(block.text)}</${tag}>`;
+    }
+    case 'list': {
+      const tag = block.ordered ? 'ol' : 'ul';
+      const items = block.items.map(i => `<li>${xmlEscape(i)}</li>`).join('');
+      return `<${tag}>${items}</${tag}>`;
+    }
+    case 'quote': {
+      const cite = block.cite ? `<cite>— ${xmlEscape(block.cite)}</cite>` : '';
+      return `<blockquote><p>${xmlEscape(block.text)}</p>${cite}</blockquote>`;
+    }
+    case 'image': {
+      const caption = block.caption
+        ? `<figcaption>${xmlEscape(block.caption)}</figcaption>`
+        : '';
+      return `<figure><img src="${xmlEscape(block.src)}" alt="${xmlEscape(block.alt)}" />${caption}</figure>`;
+    }
+    case 'code': {
+      const lang = block.language ? ` data-language="${xmlEscape(block.language)}"` : '';
+      return `<pre${lang}><code>${xmlEscape(block.code)}</code></pre>`;
+    }
+    default:
+      return '';
+  }
+};
+
+const renderItem = (post: BlogPost): string => {
+  const link = localizedUrl(AppConfig.defaultLocale, `/blog/${post.slug}`);
+  const html = post.body.map(renderBlockToHtml).join('\n');
+  const pubDate = new Date(post.publishedAt).toUTCString();
+  const category = post.category
+    ? `    <category><![CDATA[${post.category}]]></category>`
+    : '';
+  const enclosure = post.coverImage
+    ? `    <media:content url="${xmlEscape(post.coverImage)}" medium="image" />`
+    : '';
+  const author = post.author?.name
+    ? `    <dc:creator><![CDATA[${post.author.name}]]></dc:creator>`
+    : '';
+  return [
+    '  <item>',
+    `    <title><![CDATA[${post.title}]]></title>`,
+    `    <link>${xmlEscape(link)}</link>`,
+    `    <guid isPermaLink="true">${xmlEscape(link)}</guid>`,
+    `    <pubDate>${pubDate}</pubDate>`,
+    `    <description><![CDATA[${post.excerpt}]]></description>`,
+    `    <content:encoded><![CDATA[${html}]]></content:encoded>`,
+    author,
+    category,
+    enclosure,
+    '  </item>',
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+export async function GET() {
+  const posts = (await getPostsSafe())
+    .filter(isPublished)
+    .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+
+  const baseUrl = getBaseUrl();
+  const blogUrl = `${baseUrl}/blog`;
+  const feedUrl = `${baseUrl}/feed.xml`;
+  const lastBuildDate = (
+    posts[0]?.publishedAt ? new Date(posts[0].publishedAt) : new Date()
+  ).toUTCString();
+
+  const body = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    // Stylesheet directive: browsers transform the feed into a styled HTML
+    // landing page; feed readers ignore the line.
+    '<?xml-stylesheet type="text/xsl" href="/feed.xsl"?>',
+    '<rss version="2.0"',
+    '  xmlns:atom="http://www.w3.org/2005/Atom"',
+    '  xmlns:content="http://purl.org/rss/1.0/modules/content/"',
+    '  xmlns:dc="http://purl.org/dc/elements/1.1/"',
+    '  xmlns:media="http://search.yahoo.com/mrss/">',
+    '  <channel>',
+    `    <title>${xmlEscape(FEED_TITLE)}</title>`,
+    `    <link>${xmlEscape(blogUrl)}</link>`,
+    `    <description>${xmlEscape(FEED_DESCRIPTION)}</description>`,
+    '    <language>pt-BR</language>',
+    `    <lastBuildDate>${lastBuildDate}</lastBuildDate>`,
+    `    <atom:link href="${xmlEscape(feedUrl)}" rel="self" type="application/rss+xml" />`,
+    posts.map(renderItem).join('\n'),
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n');
+
+  return new NextResponse(body, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      // 5 min at edge, 15 min at origin — feed readers poll on schedule, so
+      // a short cache keeps load down without making subscribers wait.
+      'Cache-Control': 'public, max-age=300, s-maxage=900',
+    },
+  });
+}

--- a/src/components/blog/SubscribeForm.tsx
+++ b/src/components/blog/SubscribeForm.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+
+type SubmitState
+  = | { kind: 'idle' }
+    | { kind: 'submitting' }
+    | { kind: 'success' }
+    | { kind: 'error'; message: string };
+
+type SubscribeFormProps = {
+  source?: string;
+};
+
+const COPY = {
+  eyebrow: 'Receba no e-mail',
+  title: 'Novos artigos toda semana',
+  subtitle:
+    'Conteúdo curto sobre tecnologia, IA e bastidores do time. Sem spam, com link para cancelar em todo e-mail.',
+  emailLabel: 'Seu melhor e-mail',
+  cta: 'Assinar',
+  ctaLoading: 'Enviando…',
+  successTitle: 'Falta um clique',
+  successBody:
+    'Mandamos um e-mail de confirmação. Abra sua caixa de entrada e confirme para começar a receber.',
+  errorGeneric: 'Algo deu errado. Tente de novo em alguns minutos.',
+  invalidEmail: 'Esse e-mail parece inválido.',
+  privacy: 'Você pode cancelar a inscrição a qualquer momento.',
+};
+
+const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
+  const [email, setEmail] = useState('');
+  const [state, setState] = useState<SubmitState>({ kind: 'idle' });
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (state.kind === 'submitting') {
+      return;
+    }
+    const trimmed = email.trim();
+    if (!/^[^\s@]+@[^\s@][^\s.@]*\.[^\s@]+$/.test(trimmed)) {
+      setState({ kind: 'error', message: COPY.invalidEmail });
+      return;
+    }
+    setState({ kind: 'submitting' });
+    try {
+      const res = await fetch('/api/blog/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: trimmed, source, locale: 'pt-BR' }),
+      });
+      if (!res.ok) {
+        const detail: { error?: string } = await res.json().catch(() => ({}));
+        // We don't surface the specific error to the user; transient or
+        // validation issues all read the same "try again" line.
+        setState({
+          kind: 'error',
+          message: detail.error === 'invalid_request' ? COPY.invalidEmail : COPY.errorGeneric,
+        });
+        return;
+      }
+      setState({ kind: 'success' });
+      setEmail('');
+    } catch {
+      setState({ kind: 'error', message: COPY.errorGeneric });
+    }
+  };
+
+  if (state.kind === 'success') {
+    return (
+      <section className="mx-auto my-20 max-w-3xl rounded-3xl border border-stone-200/70 bg-white p-10 text-center shadow-[0_1px_2px_rgba(0,0,0,0.02)] sm:p-14">
+        <p className="mb-4 inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary">
+          <span aria-hidden className="h-px w-8 bg-primary" />
+          {COPY.eyebrow}
+        </p>
+        <h2 className="text-2xl font-semibold leading-tight tracking-[-0.02em] text-stone-900 md:text-3xl">
+          {COPY.successTitle}
+        </h2>
+        <p className="mx-auto mt-4 max-w-md text-[15px] leading-relaxed text-stone-500">
+          {COPY.successBody}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto my-20 max-w-3xl rounded-3xl border border-stone-200/70 bg-white p-10 shadow-[0_1px_2px_rgba(0,0,0,0.02)] sm:p-14">
+      <div className="text-center">
+        <p className="mb-4 inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary">
+          <span aria-hidden className="h-px w-8 bg-primary" />
+          {COPY.eyebrow}
+        </p>
+        <h2 className="text-2xl font-semibold leading-tight tracking-[-0.02em] text-stone-900 md:text-[1.875rem]">
+          {COPY.title}
+        </h2>
+        <p className="mx-auto mt-4 max-w-md text-[15px] leading-relaxed text-stone-500">
+          {COPY.subtitle}
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="mt-8 flex flex-col gap-3 sm:flex-row" noValidate>
+        <label className="flex-1">
+          <span className="sr-only">{COPY.emailLabel}</span>
+          <input
+            type="email"
+            inputMode="email"
+            autoComplete="email"
+            required
+            placeholder={COPY.emailLabel}
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              if (state.kind === 'error') {
+                setState({ kind: 'idle' });
+              }
+            }}
+            disabled={state.kind === 'submitting'}
+            aria-invalid={state.kind === 'error'}
+            className="h-12 w-full rounded-full border border-stone-200/70 bg-stone-50 px-5 text-[15px] text-stone-900 outline-none transition-colors placeholder:text-stone-400 hover:border-stone-300 focus:border-stone-400 focus:bg-white focus:ring-4 focus:ring-stone-900/5"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={state.kind === 'submitting'}
+          className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-stone-900 px-6 text-[14px] font-medium tracking-tight text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all hover:bg-stone-800 hover:shadow-[0_4px_12px_rgba(0,0,0,0.12),inset_0_1px_0_rgba(255,255,255,0.08)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {state.kind === 'submitting' ? COPY.ctaLoading : COPY.cta}
+          {state.kind !== 'submitting' && (
+            <span aria-hidden className="text-stone-400">→</span>
+          )}
+        </button>
+      </form>
+
+      <div className="mt-4 flex min-h-[20px] items-center justify-center text-[12px]">
+        {state.kind === 'error'
+          ? (
+              <p className="text-rose-600" role="alert">
+                {state.message}
+              </p>
+            )
+          : (
+              <p className="text-stone-400">{COPY.privacy}</p>
+            )}
+      </div>
+    </section>
+  );
+};
+
+export default SubscribeForm;

--- a/src/components/blog/index.ts
+++ b/src/components/blog/index.ts
@@ -15,3 +15,4 @@ export {
   slugifyCategory,
 } from './categories';
 export { formatLongDate, formatShortDate } from './formatDate';
+export { default as SubscribeForm } from './SubscribeForm';

--- a/src/libs/email/config.ts
+++ b/src/libs/email/config.ts
@@ -1,0 +1,13 @@
+// Shared email configuration. The sender mailbox doubles as Reply-To so
+// readers can reply naturally — it's a real inbox, not a noreply.
+export const EMAIL_CONFIG = {
+  fromName: 'Agility Creative',
+  fromAddress: 'hi@agilitycreative.com',
+  replyTo: 'hi@agilitycreative.com',
+  brandColor: '#FD512E',
+  // Used inside email bodies as the "View on the web" link and to sign URLs.
+  baseUrl: process.env.NEXT_PUBLIC_APP_URL || 'https://www.agilitycreative.com',
+} as const;
+
+export const formatSender = () =>
+  `${EMAIL_CONFIG.fromName} <${EMAIL_CONFIG.fromAddress}>`;

--- a/src/libs/email/notifyNewPost.ts
+++ b/src/libs/email/notifyNewPost.ts
@@ -1,0 +1,107 @@
+import { EMAIL_CONFIG } from '@/libs/email/config';
+import { sendEmail } from '@/libs/email/sender';
+import { buildNewPostEmail } from '@/libs/email/templates/new-post';
+import { listConfirmedSubscribers } from '@/libs/subscribers';
+import type { BlogPost } from '@/types/blog';
+
+const PER_SEND_DELAY_MS = 110; // 9 sends/sec → safely under Resend's 10/sec ceiling.
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const buildUnsubscribeUrl = (token: string) =>
+  `${EMAIL_CONFIG.baseUrl}/api/blog/unsubscribe?token=${encodeURIComponent(token)}`;
+
+const buildPostUrl = (slug: string) => `${EMAIL_CONFIG.baseUrl}/blog/${slug}`;
+
+export type NotifyResult = {
+  attempted: number;
+  sent: number;
+  skipped: number;
+  failed: number;
+};
+
+/**
+ * Fan out a "new post" email to every confirmed subscriber. Called after a
+ * successful publish (status going to `published` for the first time).
+ *
+ * Errors are swallowed per-recipient — we never want a single bad address to
+ * block the publish, and `listConfirmedSubscribers` is the source of truth so
+ * a transient failure can be retried later without producing duplicates
+ * (Phase 3 if we ever need it; for now Resend's own retries are enough).
+ */
+export const notifyNewPost = async (post: BlogPost): Promise<NotifyResult> => {
+  // Drafts shouldn't reach here, but the cheap check makes the function safe
+  // for callers that re-run the publish action.
+  if (post.status === 'draft') {
+    return { attempted: 0, sent: 0, skipped: 0, failed: 0 };
+  }
+
+  const subscribers = await listConfirmedSubscribers();
+  const result: NotifyResult = {
+    attempted: subscribers.length,
+    sent: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  for (const sub of subscribers) {
+    const unsubscribeUrl = buildUnsubscribeUrl(sub.unsubscribeToken);
+    const { subject, html, text } = buildNewPostEmail({
+      title: post.title,
+      excerpt: post.excerpt,
+      category: post.category,
+      coverImage: post.coverImage,
+      coverAlt: post.coverAlt,
+      postUrl: buildPostUrl(post.slug),
+      unsubscribeUrl,
+    });
+
+    const send = await sendEmail({
+      to: sub.email,
+      subject,
+      html,
+      text,
+      headers: {
+        // Both forms — Gmail/Apple Mail accept either; some legacy clients
+        // only look at <…> URI form, others want mailto:.
+        'List-Unsubscribe': `<${unsubscribeUrl}>, <mailto:${EMAIL_CONFIG.replyTo}?subject=unsubscribe>`,
+        // RFC 8058 — Gmail's "Unsubscribe" button needs this to one-click.
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      },
+    });
+
+    if (send.ok) {
+      result.sent += 1;
+    } else if (send.skipped) {
+      result.skipped += 1;
+    } else {
+      result.failed += 1;
+
+      console.error('[notifyNewPost] send failed', sub.email, send.error);
+    }
+
+    // Polite throttle so we don't trip Resend's rate limiter on bigger lists.
+
+    await sleep(PER_SEND_DELAY_MS);
+  }
+
+  return result;
+};
+
+/**
+ * Trigger the fan-out without awaiting it from the request handler. We rely
+ * on Vercel's behavior of running pending work after the response is sent
+ * (limited to ~10s on the Hobby plan, ~60s on Pro) — for blog volume that's
+ * comfortably more than enough.
+ *
+ * If the runtime cuts the work short, the worst case is some subscribers
+ * miss this post — they still get the next one, and the original publish
+ * action succeeded either way.
+ */
+export const fireNewPostNotification = (post: BlogPost): void => {
+  if (post.status !== 'published') {
+    return;
+  }
+
+  notifyNewPost(post).catch(err => console.error('[notifyNewPost] failed', err));
+};

--- a/src/libs/email/sender.ts
+++ b/src/libs/email/sender.ts
@@ -1,0 +1,71 @@
+import { Resend } from 'resend';
+
+import { EMAIL_CONFIG, formatSender } from './config';
+
+let cachedClient: Resend | null = null;
+
+const getClient = (): Resend | null => {
+  if (cachedClient) {
+    return cachedClient;
+  }
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    return null;
+  }
+  cachedClient = new Resend(apiKey);
+  return cachedClient;
+};
+
+export type SendEmailInput = {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+  // Extra headers — used for List-Unsubscribe (Gmail/Apple Mail bonus) and
+  // anything else the caller needs.
+  headers?: Record<string, string>;
+};
+
+export type SendEmailResult
+  = | { ok: true; id: string }
+    | { ok: false; error: string; skipped?: boolean };
+
+/**
+ * Send a transactional email via Resend. Returns a structured result instead
+ * of throwing so callers can fan out and decide what to do per-recipient.
+ *
+ * In environments without `RESEND_API_KEY` (CI, local without an account), the
+ * send is **skipped** rather than failing — this lets the rest of the publish
+ * flow keep working in dev. The skipped flag surfaces that to logs.
+ */
+export const sendEmail = async (input: SendEmailInput): Promise<SendEmailResult> => {
+  const client = getClient();
+  if (!client) {
+    return {
+      ok: false,
+      error: 'resend_not_configured',
+      skipped: true,
+    };
+  }
+
+  try {
+    const response = await client.emails.send({
+      from: formatSender(),
+      to: input.to,
+      replyTo: EMAIL_CONFIG.replyTo,
+      subject: input.subject,
+      html: input.html,
+      text: input.text,
+      headers: input.headers,
+    });
+    if (response.error) {
+      return { ok: false, error: response.error.message };
+    }
+    return { ok: true, id: response.data?.id ?? '' };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'unknown_error',
+    };
+  }
+};

--- a/src/libs/email/templates/confirm.ts
+++ b/src/libs/email/templates/confirm.ts
@@ -1,0 +1,56 @@
+import { EMAIL_CONFIG } from '../config';
+import { escape, wrapHtml } from './shared';
+
+export type ConfirmEmailInput = {
+  confirmUrl: string;
+};
+
+const SUBJECT = 'Confirme sua inscrição no blog da Agility';
+
+const previewText = 'Falta um clique para começar a receber novos artigos.';
+
+const renderHtml = (input: ConfirmEmailInput): string => {
+  const inner = `
+    <h1 style="margin:0 0 20px;font-size:24px;font-weight:600;letter-spacing:-.02em;line-height:1.2;color:#1c1917;">
+      Falta um clique para confirmar
+    </h1>
+    <p style="margin:0 0 28px;font-size:15px;line-height:1.65;color:#44403c;">
+      Obrigado por assinar o blog da Agility Creative. Para começar a receber
+      novos artigos, confirme que este e-mail é seu clicando no botão abaixo.
+    </p>
+    <p style="margin:0 0 36px;">
+      <a href="${escape(input.confirmUrl)}"
+         style="display:inline-block;padding:13px 22px;background:#1c1917;color:#fafaf9;border-radius:999px;text-decoration:none;font-size:14px;font-weight:500;letter-spacing:-.005em;">
+        Confirmar inscrição
+      </a>
+    </p>
+    <p style="margin:0 0 8px;font-size:12px;line-height:1.55;color:#78716c;">
+      Ou copie e cole este link no navegador:
+    </p>
+    <p style="margin:0 0 32px;font-size:12px;line-height:1.4;color:#78716c;word-break:break-all;">
+      <a href="${escape(input.confirmUrl)}" style="color:#78716c;">${escape(input.confirmUrl)}</a>
+    </p>
+    <p style="margin:0;font-size:13px;line-height:1.6;color:#78716c;">
+      Se você não se inscreveu, é só ignorar este e-mail — sem confirmação não
+      enviaremos mais nada.
+    </p>
+  `;
+  return wrapHtml(inner, { previewText });
+};
+
+const renderText = (input: ConfirmEmailInput): string => `
+Falta um clique para confirmar sua inscrição no blog da Agility Creative.
+
+Confirme aqui:
+${input.confirmUrl}
+
+Se você não se inscreveu, é só ignorar este e-mail — sem confirmação não enviaremos mais nada.
+
+— Equipe Agility (${EMAIL_CONFIG.fromAddress})
+`.trim();
+
+export const buildConfirmEmail = (input: ConfirmEmailInput) => ({
+  subject: SUBJECT,
+  html: renderHtml(input),
+  text: renderText(input),
+});

--- a/src/libs/email/templates/new-post.ts
+++ b/src/libs/email/templates/new-post.ts
@@ -1,0 +1,62 @@
+import { EMAIL_CONFIG } from '../config';
+import { escape, wrapHtml } from './shared';
+
+export type NewPostEmailInput = {
+  title: string;
+  excerpt: string;
+  category?: string;
+  coverImage?: string;
+  coverAlt?: string;
+  postUrl: string;
+  unsubscribeUrl: string;
+};
+
+const renderHtml = (input: NewPostEmailInput): string => {
+  const category = input.category
+    ? `<p style="margin:0 0 16px;font-size:11px;font-weight:600;letter-spacing:.18em;text-transform:uppercase;color:${EMAIL_CONFIG.brandColor};">
+        ${escape(input.category)}
+      </p>`
+    : '';
+  const cover = input.coverImage
+    ? `<a href="${escape(input.postUrl)}" style="display:block;margin:0 0 28px;border-radius:14px;overflow:hidden;text-decoration:none;">
+        <img src="${escape(input.coverImage)}" alt="${escape(input.coverAlt ?? input.title)}"
+             width="512" style="display:block;width:100%;max-width:512px;height:auto;border:0;outline:none;text-decoration:none;border-radius:14px;" />
+      </a>`
+    : '';
+  const inner = `
+    ${cover}
+    ${category}
+    <h1 style="margin:0 0 16px;font-size:26px;font-weight:600;letter-spacing:-.02em;line-height:1.2;color:#1c1917;">
+      ${escape(input.title)}
+    </h1>
+    <p style="margin:0 0 32px;font-size:15px;line-height:1.65;color:#44403c;">
+      ${escape(input.excerpt)}
+    </p>
+    <p style="margin:0 0 8px;">
+      <a href="${escape(input.postUrl)}"
+         style="display:inline-block;padding:13px 22px;background:#1c1917;color:#fafaf9;border-radius:999px;text-decoration:none;font-size:14px;font-weight:500;letter-spacing:-.005em;">
+        Ler artigo completo →
+      </a>
+    </p>
+  `;
+  return wrapHtml(inner, { previewText: input.excerpt, unsubscribeUrl: input.unsubscribeUrl });
+};
+
+const renderText = (input: NewPostEmailInput): string => `
+${input.title}
+
+${input.excerpt}
+
+Ler completo: ${input.postUrl}
+
+— Equipe Agility (${EMAIL_CONFIG.fromAddress})
+
+---
+Cancelar inscrição: ${input.unsubscribeUrl}
+`.trim();
+
+export const buildNewPostEmail = (input: NewPostEmailInput) => ({
+  subject: input.title,
+  html: renderHtml(input),
+  text: renderText(input),
+});

--- a/src/libs/email/templates/shared.ts
+++ b/src/libs/email/templates/shared.ts
@@ -1,0 +1,58 @@
+// Shared building blocks for our email templates. Email HTML is its own
+// little dark age — Gmail strips <style>, Outlook ignores half of flexbox,
+// dark mode is unpredictable. We keep things minimal: inline styles, table-
+// less centering with max-width, and explicit colors on every text node.
+
+import { EMAIL_CONFIG } from '../config';
+
+export const escape = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const FONT_STACK
+  = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, "Helvetica Neue", Arial, sans-serif';
+
+export const wrapHtml = (innerHtml: string, opts: { previewText?: string; unsubscribeUrl?: string } = {}): string => {
+  const preview = opts.previewText ? escape(opts.previewText) : '';
+  const unsubscribe = opts.unsubscribeUrl
+    ? `<p style="margin:24px 0 0;font-size:11px;line-height:1.5;color:#a8a29e;text-align:center;">
+        Não quer mais receber? <a href="${escape(opts.unsubscribeUrl)}" style="color:#78716c;text-decoration:underline;">Cancelar inscrição</a>.
+      </p>`
+    : '';
+  return `<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="x-apple-disable-message-reformatting" />
+  <meta name="color-scheme" content="light" />
+  <meta name="supported-color-schemes" content="light" />
+  <title>${escape(EMAIL_CONFIG.fromName)}</title>
+</head>
+<body style="margin:0;padding:0;background:#fafaf9;font-family:${FONT_STACK};color:#1c1917;-webkit-font-smoothing:antialiased;">
+  <span style="display:none !important;visibility:hidden;mso-hide:all;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">
+    ${preview}
+  </span>
+  <div style="max-width:560px;margin:0 auto;padding:40px 24px 56px;">
+    <header style="padding-bottom:32px;border-bottom:1px solid rgba(0,0,0,.06);margin-bottom:32px;">
+      <a href="${EMAIL_CONFIG.baseUrl}/blog" style="text-decoration:none;color:#1c1917;display:inline-flex;align-items:center;gap:8px;">
+        <span style="display:inline-block;width:24px;height:24px;background:${EMAIL_CONFIG.brandColor};border-radius:6px;"></span>
+        <strong style="font-size:15px;letter-spacing:-.01em;">Agility Creative</strong>
+      </a>
+    </header>
+    ${innerHtml}
+    <footer style="margin-top:48px;padding-top:24px;border-top:1px solid rgba(0,0,0,.06);">
+      <p style="margin:0;font-size:12px;line-height:1.55;color:#78716c;">
+        Você está recebendo este e-mail porque assinou o blog da Agility Creative em
+        <a href="${EMAIL_CONFIG.baseUrl}/blog" style="color:#78716c;">agilitycreative.com</a>.
+      </p>
+      ${unsubscribe}
+    </footer>
+  </div>
+</body>
+</html>`;
+};

--- a/src/libs/subscribers.ts
+++ b/src/libs/subscribers.ts
@@ -1,0 +1,159 @@
+import crypto from 'node:crypto';
+
+import { and, eq } from 'drizzle-orm';
+
+import { db } from '@/libs/DB';
+import type { BlogSubscriber } from '@/models/Schema';
+import { blogSubscribersSchema } from '@/models/Schema';
+
+export type SubscriberStatus = 'pending' | 'confirmed' | 'unsubscribed';
+
+const TOKEN_BYTES = 32;
+
+const newToken = () => crypto.randomBytes(TOKEN_BYTES).toString('hex');
+
+const normalizeEmail = (email: string) => email.trim().toLowerCase();
+
+export type SubscribeResult
+  = | { kind: 'created'; subscriber: BlogSubscriber }
+    | { kind: 'resent'; subscriber: BlogSubscriber }
+    | { kind: 'already_confirmed'; subscriber: BlogSubscriber };
+
+/**
+ * Add a new subscriber or rotate the confirm-token for an existing pending one.
+ * - new address → `created` (status 'pending', new tokens)
+ * - already pending → `resent` (fresh confirm token so the link in the previous
+ *   email stops working — prevents stale-link confusion)
+ * - already confirmed → `already_confirmed` (don't change anything; the caller
+ *   should respond with a friendly "you're already in" message)
+ * - previously unsubscribed → resurrected as pending (counts as a fresh consent)
+ */
+export const subscribe = async (
+  emailInput: string,
+  options: { locale?: string; source?: string } = {},
+): Promise<SubscribeResult> => {
+  const email = normalizeEmail(emailInput);
+  const existing = await db
+    .select()
+    .from(blogSubscribersSchema)
+    .where(eq(blogSubscribersSchema.email, email))
+    .limit(1);
+
+  const current = existing[0];
+
+  if (current && current.status === 'confirmed') {
+    return { kind: 'already_confirmed', subscriber: current };
+  }
+
+  const confirmToken = newToken();
+  const unsubscribeToken = current?.unsubscribeToken ?? newToken();
+  const locale = options.locale ?? 'pt-BR';
+  const source = options.source;
+
+  if (!current) {
+    const inserted = await db
+      .insert(blogSubscribersSchema)
+      .values({
+        email,
+        status: 'pending',
+        confirmToken,
+        unsubscribeToken,
+        locale,
+        source,
+      })
+      .returning();
+    return { kind: 'created', subscriber: inserted[0]! };
+  }
+
+  // Pending or previously unsubscribed → bring back to pending with a fresh
+  // confirm token. Unsubscribed reactivation counts as a new consent (LGPD).
+  const updated = await db
+    .update(blogSubscribersSchema)
+    .set({
+      status: 'pending',
+      confirmToken,
+      locale,
+      source,
+      unsubscribedAt: null,
+      confirmedAt: null,
+    })
+    .where(eq(blogSubscribersSchema.id, current.id))
+    .returning();
+  return { kind: 'resent', subscriber: updated[0]! };
+};
+
+export type ConfirmResult
+  = | { ok: true; subscriber: BlogSubscriber; alreadyConfirmed: boolean }
+    | { ok: false; reason: 'invalid_token' };
+
+export const confirmByToken = async (token: string): Promise<ConfirmResult> => {
+  if (!token || token.length !== TOKEN_BYTES * 2) {
+    return { ok: false, reason: 'invalid_token' };
+  }
+  const rows = await db
+    .select()
+    .from(blogSubscribersSchema)
+    .where(eq(blogSubscribersSchema.confirmToken, token))
+    .limit(1);
+  const subscriber = rows[0];
+  if (!subscriber) {
+    return { ok: false, reason: 'invalid_token' };
+  }
+  if (subscriber.status === 'confirmed') {
+    return { ok: true, subscriber, alreadyConfirmed: true };
+  }
+  const updated = await db
+    .update(blogSubscribersSchema)
+    .set({ status: 'confirmed', confirmedAt: new Date() })
+    .where(eq(blogSubscribersSchema.id, subscriber.id))
+    .returning();
+  return { ok: true, subscriber: updated[0]!, alreadyConfirmed: false };
+};
+
+export type UnsubscribeResult
+  = | { ok: true; subscriber: BlogSubscriber; alreadyUnsubscribed: boolean }
+    | { ok: false; reason: 'invalid_token' };
+
+export const unsubscribeByToken = async (token: string): Promise<UnsubscribeResult> => {
+  if (!token || token.length !== TOKEN_BYTES * 2) {
+    return { ok: false, reason: 'invalid_token' };
+  }
+  const rows = await db
+    .select()
+    .from(blogSubscribersSchema)
+    .where(eq(blogSubscribersSchema.unsubscribeToken, token))
+    .limit(1);
+  const subscriber = rows[0];
+  if (!subscriber) {
+    return { ok: false, reason: 'invalid_token' };
+  }
+  if (subscriber.status === 'unsubscribed') {
+    return { ok: true, subscriber, alreadyUnsubscribed: true };
+  }
+  const updated = await db
+    .update(blogSubscribersSchema)
+    .set({ status: 'unsubscribed', unsubscribedAt: new Date() })
+    .where(eq(blogSubscribersSchema.id, subscriber.id))
+    .returning();
+  return { ok: true, subscriber: updated[0]!, alreadyUnsubscribed: false };
+};
+
+/**
+ * Confirmed subscribers — the audience for new-post notifications. Returns
+ * `{ email, unsubscribeToken }` only since that's all the fan-out needs.
+ */
+export const listConfirmedSubscribers = async (): Promise<
+  Pick<BlogSubscriber, 'email' | 'unsubscribeToken'>[]
+> => {
+  return db
+    .select({
+      email: blogSubscribersSchema.email,
+      unsubscribeToken: blogSubscribersSchema.unsubscribeToken,
+    })
+    .from(blogSubscribersSchema)
+    .where(
+      and(
+        eq(blogSubscribersSchema.status, 'confirmed'),
+      ),
+    );
+};

--- a/src/models/Schema.ts
+++ b/src/models/Schema.ts
@@ -1,4 +1,4 @@
-import { integer, jsonb, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+import { index, integer, jsonb, pgTable, serial, text, timestamp, uniqueIndex, varchar } from 'drizzle-orm/pg-core';
 
 import type { BlogPost } from '@/types/blog';
 
@@ -23,3 +23,42 @@ export const blogStoreSchema = pgTable('blog_store', {
     .$onUpdate(() => new Date())
     .notNull(),
 });
+
+// Email subscribers for the blog. Double opt-in: rows start as 'pending',
+// move to 'confirmed' when the user clicks the confirmation link, and to
+// 'unsubscribed' when they opt out. We never delete rows — keeping the
+// history matters for LGPD / CAN-SPAM audits ("when did this address last
+// consent?") and for preventing accidental re-sends after an unsubscribe.
+export const blogSubscribersSchema = pgTable(
+  'blog_subscribers',
+  {
+    id: serial('id').primaryKey(),
+    // Normalized to lowercase by the application before insertion.
+    email: varchar('email', { length: 320 }).notNull(),
+    // 'pending' | 'confirmed' | 'unsubscribed'
+    status: varchar('status', { length: 16 }).notNull().default('pending'),
+    // 64 hex chars = 32 random bytes — used in the confirm/unsubscribe URLs.
+    confirmToken: varchar('confirm_token', { length: 64 }).notNull(),
+    unsubscribeToken: varchar('unsubscribe_token', { length: 64 }).notNull(),
+    locale: varchar('locale', { length: 8 }).notNull().default('pt-BR'),
+    // Source page or campaign — useful later for attribution. Free-form.
+    source: varchar('source', { length: 64 }),
+    confirmedAt: timestamp('confirmed_at', { mode: 'date' }),
+    unsubscribedAt: timestamp('unsubscribed_at', { mode: 'date' }),
+    createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { mode: 'date' })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  table => ({
+    emailIdx: uniqueIndex('blog_subscribers_email_idx').on(table.email),
+    confirmTokenIdx: uniqueIndex('blog_subscribers_confirm_token_idx').on(table.confirmToken),
+    unsubscribeTokenIdx: uniqueIndex('blog_subscribers_unsubscribe_token_idx').on(
+      table.unsubscribeToken,
+    ),
+    statusIdx: index('blog_subscribers_status_idx').on(table.status),
+  }),
+);
+
+export type BlogSubscriber = typeof blogSubscribersSchema.$inferSelect;

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -40,8 +40,14 @@ export const buildAlternates = (locale: Locale, path: string) => {
  * canonical and every hreflang point at the same default-locale URL, and we
  * intentionally omit other locales so search engines don't crawl URLs that
  * just redirect.
+ *
+ * Pass `withRssFeed: true` on blog pages to advertise the RSS feed via
+ * `<link rel="alternate" type="application/rss+xml">` for auto-discovery.
  */
-export const buildDefaultLocaleAlternates = (path: string) => {
+export const buildDefaultLocaleAlternates = (
+  path: string,
+  options: { withRssFeed?: boolean } = {},
+) => {
   const defaultPath = localizedPath(AppConfig.defaultLocale, path);
   return {
     canonical: defaultPath,
@@ -49,6 +55,15 @@ export const buildDefaultLocaleAlternates = (path: string) => {
       [AppConfig.defaultLocale]: defaultPath,
       'x-default': defaultPath,
     },
+    ...(options.withRssFeed
+      ? {
+          types: {
+            'application/rss+xml': [
+              { url: '/feed.xml', title: 'Agility Creative — Blog' },
+            ],
+          },
+        }
+      : {}),
   };
 };
 


### PR DESCRIPTION
## What this ships
Two coupled features, one PR because they share data flow (the publish hook fires emails to the same list that the RSS feed serves).

### RSS feed (`/feed.xml` + `/rss.xml`)
- Valid RSS 2.0 with `content:encoded` (sanitized body blocks → HTML), `media:content` for cover images, `dc:creator`, `atom:link rel="self"`.
- `?xml-stylesheet` directive pointing at `public/feed.xsl` — readers ignore it; humans visiting in a browser get a styled landing page (Feedly subscribe button, raw URL, recent items list) instead of raw XML.
- Auto-discoverable via `<link rel="alternate" type="application/rss+xml">` on every blog page (added through the new `withRssFeed` option on `buildDefaultLocaleAlternates`).
- Same `rewrites.beforeFiles` pattern as `/sitemap.xml` to sidestep Next.js's metadata convention.

### Email subscribers (double opt-in via Resend)
- **Schema** — new `blog_subscribers` table (migration `0002_natural_nehzno.sql`): `email` (unique), `status` (`pending` | `confirmed` | `unsubscribed`), `confirm_token` + `unsubscribe_token` (32 random bytes each), `locale`, `source`, timestamps. We never delete rows — keeping the history matters for LGPD/CAN-SPAM ("when did this address last consent?").
- **API**
  - `POST /api/blog/subscribe` — public, zod-validated, sends confirmation email. Generic response shape so an attacker can't enumerate existing subscribers via timing/content.
  - `GET /api/blog/confirm?token=…` — flips status to `confirmed`, renders a stone-palette success page.
  - `GET /api/blog/unsubscribe?token=…` — one-click via the link in every email.
  - `POST /api/blog/unsubscribe?token=…` — RFC 8058 one-click for the Gmail/Apple Mail "Unsubscribe" button (`List-Unsubscribe-Post: List-Unsubscribe=One-Click`).
- **Resend wrapper** (`src/libs/email/sender.ts`) — guarded by `RESEND_API_KEY`. Missing env → returns `{ ok: false, skipped: true }` so dev/CI doesn't blow up. From + Reply-To: `hi@agilitycreative.com`.
- **Templates** (raw HTML — no React-Email runtime weight): `confirm.ts` and `new-post.ts`, both with plain-text fallbacks, hidden preview text, inline styles only (Gmail strips `<style>`).
- **Publish fan-out** (`src/libs/email/notifyNewPost.ts`) — fires on three transitions:
  - `create` action with `status: 'published'` (the default)
  - `update` action when the patch moves status `draft` → `published`
  - `publish` action when `changed === true`
  
  Fires non-blocking (`fireNewPostNotification` doesn't await — Vercel runs pending work after the response is sent). Per-email throttle ≈ 9/s to stay under Resend's 10/s ceiling. `List-Unsubscribe` header on every send.
- **Subscribe form** (`src/components/blog/SubscribeForm.tsx`) — at the bottom of `/blog`, stone palette, optimistic UI, accessible (sr-only label, `aria-invalid`, `role="alert"`).

## What you need to do **before merging**
- [x] **Sign up at https://resend.com** — done?
- [x] **`RESEND_API_KEY` added to Vercel production env** — done (just now via `vercel env add`).
- [ ] **Add DNS records on `agilitycreative.com`** — Resend gives you 3 records (SPF, DKIM, DMARC) under "Domains" in their dashboard. Until those propagate, sends will be rejected by most receivers. ~10 min to add, up to 24 h to propagate (usually faster).

## What you need to do **right after merging**
1. Watch Vercel build → it auto-applies `migrations/0002_natural_nehzno.sql` on first DB connect (creates `blog_subscribers`).
2. **Rotate the Resend API key** — the key you shared in chat is in the conversation transcript. Generate a new one in Resend → update Vercel env → invalidate the old one. I've used it for the initial setup but it should be considered compromised.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 141/141 across 25 files (route test mocks the notify module so it stays hermetic)
- [x] Local: `/feed.xml` returns `application/rss+xml`, contains stylesheet directive, lists 4 published posts
- [x] Local: `/rss.xml` alias works
- [x] Local: `POST /api/blog/subscribe` with valid email → 200 `{ ok: true, status: 'pending' }`
- [x] Local: invalid email → 400 `invalid_request`
- [ ] **Prod (after merge)**: subscribe with your address → confirmation email lands → click confirm → publish a draft via the bot → "new post" email lands → click unsubscribe → confirm landing page

## Notes
- `src/data/blog.json` untouched. Existing posts in the Postgres `blog_store` untouched.
- Existing publish behavior preserved end-to-end; the notification is purely additive.
- Tests mock `@/libs/email/notifyNewPost` to keep the route test from pulling in DB / Resend.