### PR TITLE
feat(blog): subscribe timeout + dedicated confirm/unsubscribe pages

### DIFF
--- a/src/app/[locale]/blog/confirm/page.tsx
+++ b/src/app/[locale]/blog/confirm/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from 'next';
+
+import { BlogHero } from '@/components/blog';
+import { Link } from '@/libs/i18nNavigation';
+import { confirmByToken } from '@/libs/subscribers';
+
+export const dynamic = 'force-dynamic';
+
+// Confirmation pages must never be indexed — they're transactional landing
+// pages, not content. Excluding them also stops GSC from flagging the empty
+// `?token` variant as a duplicate.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  title: 'Confirmação de inscrição',
+};
+
+type Params = { token?: string | string[] };
+
+const pickToken = (raw: Params['token']): string => {
+  if (Array.isArray(raw)) {
+    return raw[0] ?? '';
+  }
+  return raw ?? '';
+};
+
+const ConfirmPage = async ({
+  searchParams,
+}: {
+  searchParams: Promise<Params>;
+}) => {
+  const { token: rawToken } = await searchParams;
+  const token = pickToken(rawToken);
+  const result = token ? await confirmByToken(token) : { ok: false as const, reason: 'invalid_token' as const };
+
+  if (!result.ok) {
+    return (
+      <>
+        <BlogHero
+          eyebrow="Algo deu errado"
+          title="Esse link não funciona mais"
+          subtitle="O link pode ter expirado depois que você pediu uma nova confirmação, ou pode ter sido digitado errado. Tente assinar de novo no blog."
+        />
+        <section className="mx-auto max-w-3xl px-5 py-16 sm:px-8">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 rounded-full bg-stone-900 px-5 py-2.5 text-[13px] font-medium text-stone-50 transition-colors hover:bg-stone-800"
+          >
+            Voltar para o blog
+            <span aria-hidden className="text-stone-400">→</span>
+          </Link>
+        </section>
+      </>
+    );
+  }
+
+  const alreadyConfirmed = result.alreadyConfirmed;
+
+  return (
+    <>
+      <BlogHero
+        eyebrow={alreadyConfirmed ? 'Você já estava dentro' : 'Inscrição confirmada'}
+        title={alreadyConfirmed ? 'Você já é assinante' : 'Pronto, está confirmado'}
+        subtitle={
+          alreadyConfirmed
+            ? 'Esse e-mail já tinha sido confirmado em uma sessão anterior. Você vai continuar recebendo cada artigo novo.'
+            : 'Você vai receber um e-mail toda vez que publicarmos um artigo novo. Leituras curtas, em pt-BR, sobre tecnologia, IA e produto.'
+        }
+      />
+      <section className="mx-auto max-w-3xl px-5 py-16 sm:px-8">
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 rounded-full bg-stone-900 px-5 py-2.5 text-[13px] font-medium text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all hover:bg-stone-800"
+          >
+            Ler os artigos
+            <span aria-hidden className="text-stone-400">→</span>
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 rounded-full border border-stone-200/70 bg-white px-5 py-2.5 text-[13px] font-medium text-stone-600 transition-colors hover:border-stone-300 hover:text-stone-900"
+          >
+            Ir para o site
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default ConfirmPage;

--- a/src/app/[locale]/blog/unsubscribe/page.tsx
+++ b/src/app/[locale]/blog/unsubscribe/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from 'next';
+
+import { BlogHero } from '@/components/blog';
+import { Link } from '@/libs/i18nNavigation';
+import { unsubscribeByToken } from '@/libs/subscribers';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  title: 'Cancelar inscrição',
+};
+
+type Params = { token?: string | string[] };
+
+const pickToken = (raw: Params['token']): string => {
+  if (Array.isArray(raw)) {
+    return raw[0] ?? '';
+  }
+  return raw ?? '';
+};
+
+const UnsubscribePage = async ({
+  searchParams,
+}: {
+  searchParams: Promise<Params>;
+}) => {
+  const { token: rawToken } = await searchParams;
+  const token = pickToken(rawToken);
+  // Honoring the unsubscribe is a server side-effect — we run it as part of
+  // the page render. The token model means a missing/bad token simply shows
+  // the error variant; nothing destructive happens.
+  const result = token
+    ? await unsubscribeByToken(token)
+    : { ok: false as const, reason: 'invalid_token' as const };
+
+  if (!result.ok) {
+    return (
+      <>
+        <BlogHero
+          eyebrow="Algo deu errado"
+          title="Esse link não funciona mais"
+          subtitle="O link pode ter expirado ou sido digitado errado. Se você ainda quer parar de receber, abra um e-mail nosso recente e clique no link de “Cancelar inscrição” no rodapé."
+        />
+        <section className="mx-auto max-w-3xl px-5 py-16 sm:px-8">
+          <p className="mb-6 text-[15px] leading-relaxed text-stone-600">
+            Você também pode escrever para
+            {' '}
+            <a
+              href="mailto:hi@agilitycreative.com?subject=Cancelar%20inscri%C3%A7%C3%A3o"
+              className="text-stone-900 underline decoration-stone-300 underline-offset-4 hover:decoration-stone-500"
+            >
+              hi@agilitycreative.com
+            </a>
+            {' '}
+            que removemos manualmente.
+          </p>
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 rounded-full bg-stone-900 px-5 py-2.5 text-[13px] font-medium text-stone-50 transition-colors hover:bg-stone-800"
+          >
+            Voltar para o blog
+            <span aria-hidden className="text-stone-400">→</span>
+          </Link>
+        </section>
+      </>
+    );
+  }
+
+  const alreadyUnsubscribed = result.alreadyUnsubscribed;
+
+  return (
+    <>
+      <BlogHero
+        eyebrow={alreadyUnsubscribed ? 'Você já estava fora' : 'Inscrição cancelada'}
+        title={
+          alreadyUnsubscribed
+            ? 'Esse e-mail já tinha sido removido'
+            : 'Pronto, removemos seu e-mail'
+        }
+        subtitle={
+          alreadyUnsubscribed
+            ? 'Confirmamos: você não está mais na nossa lista. Se ainda chegar algum e-mail, pode ser um envio anterior que ficou em fila — vai parar nas próximas horas.'
+            : 'Você não vai receber mais e-mails nossos a partir de agora. Se mudou de ideia, é só assinar de novo no blog quando quiser.'
+        }
+      />
+      <section className="mx-auto max-w-3xl px-5 py-16 sm:px-8">
+        <p className="mb-8 text-[14px] leading-relaxed text-stone-500">
+          Tem um segundo para nos contar o motivo? Responda este e-mail:
+          {' '}
+          <a
+            href="mailto:hi@agilitycreative.com?subject=Por%20que%20cancelei"
+            className="text-stone-900 underline decoration-stone-300 underline-offset-4 hover:decoration-stone-500"
+          >
+            hi@agilitycreative.com
+          </a>
+          . Ajuda demais a ajustar o que enviamos.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2 rounded-full bg-stone-900 px-5 py-2.5 text-[13px] font-medium text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all hover:bg-stone-800"
+          >
+            Continuar lendo o blog
+            <span aria-hidden className="text-stone-400">→</span>
+          </Link>
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 rounded-full border border-stone-200/70 bg-white px-5 py-2.5 text-[13px] font-medium text-stone-600 transition-colors hover:border-stone-300 hover:text-stone-900"
+          >
+            Ir para o site
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default UnsubscribePage;

--- a/src/app/api/blog/confirm/route.ts
+++ b/src/app/api/blog/confirm/route.ts
@@ -1,74 +1,15 @@
 import { NextResponse } from 'next/server';
 
-import { confirmByToken } from '@/libs/subscribers';
-
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-// GET /api/blog/confirm?token=<hex> — the user clicks this from their inbox.
-// We render minimal inline HTML rather than redirecting to a route so the
-// success message is rendered even if the destination is rate-limited or down.
-
-const renderPage = (kind: 'confirmed' | 'invalid'): Response => {
-  const isConfirmed = kind === 'confirmed';
-  const title = isConfirmed
-    ? 'Inscrição confirmada'
-    : 'Link inválido ou expirado';
-  const heading = isConfirmed
-    ? 'Tudo certo. Você está dentro.'
-    : 'Esse link não funciona mais';
-  const body = isConfirmed
-    ? 'Você vai receber um e-mail toda vez que publicarmos um artigo novo. Pode esperar leituras curtas, na maioria das vezes em pt-BR, sobre tecnologia, IA e produto.'
-    : 'O link pode ter expirado depois que você pediu uma nova confirmação, ou pode ter sido digitado errado. Tente assinar de novo no blog.';
-  const ctaHref = '/blog';
-  const ctaLabel = isConfirmed ? 'Ir para o blog' : 'Voltar para o blog';
-
-  const html = `<!doctype html>
-<html lang="pt-BR">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="robots" content="noindex" />
-  <title>${title} — Agility Creative</title>
-  <style>
-    :root { color-scheme: light; }
-    * { box-sizing: border-box; }
-    html, body { margin: 0; background: #fafaf9; color: #1c1917; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, "Helvetica Neue", Arial, sans-serif; }
-    .wrap { max-width: 480px; margin: 0 auto; padding: 80px 24px 64px; }
-    .eyebrow { font-size: 11px; font-weight: 600; letter-spacing: 0.22em; text-transform: uppercase; color: #FD512E; display: inline-flex; gap: 12px; align-items: center; margin: 0 0 20px; }
-    .eyebrow::before { content: ""; width: 32px; height: 1px; background: #FD512E; display: inline-block; }
-    h1 { margin: 0 0 16px; font-size: 32px; line-height: 1.15; letter-spacing: -0.02em; font-weight: 600; }
-    p.lede { margin: 0 0 32px; color: #57534e; line-height: 1.6; font-size: 16px; }
-    .cta { display: inline-flex; align-items: center; gap: 8px; padding: 12px 20px; border-radius: 999px; background: #1c1917; color: #fafaf9; text-decoration: none; font-weight: 500; font-size: 14px; }
-    .cta:hover { background: #292524; }
-    footer { margin-top: 48px; color: #a8a29e; font-size: 12px; }
-    footer a { color: inherit; text-decoration: underline; }
-  </style>
-</head>
-<body>
-  <main class="wrap">
-    <p class="eyebrow">${isConfirmed ? 'Inscrição confirmada' : 'Algo deu errado'}</p>
-    <h1>${heading}</h1>
-    <p class="lede">${body}</p>
-    <a class="cta" href="${ctaHref}">${ctaLabel} →</a>
-    <footer>
-      <p>Agility Creative · <a href="/">agilitycreative.com</a></p>
-    </footer>
-  </main>
-</body>
-</html>`;
-
-  return new NextResponse(html, {
-    status: isConfirmed ? 200 : 400,
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'private, no-store',
-    },
-  });
-};
-
-export async function GET(req: Request) {
-  const token = new URL(req.url).searchParams.get('token') ?? '';
-  const result = await confirmByToken(token);
-  return renderPage(result.ok ? 'confirmed' : 'invalid');
+// Legacy shim: confirmation flow moved to /blog/confirm so it can use the
+// blog's BlogTemplate shell instead of inline HTML. Older confirmation
+// emails point at this URL — redirect to the new page, preserving the token.
+// The token query param survives the 308 unchanged.
+export function GET(req: Request) {
+  const url = new URL(req.url);
+  const target = new URL('/blog/confirm', url.origin);
+  target.search = url.search;
+  return NextResponse.redirect(target, 308);
 }

--- a/src/app/api/blog/subscribe/route.ts
+++ b/src/app/api/blog/subscribe/route.ts
@@ -25,7 +25,7 @@ const errorResponse = (status: number, error: string) =>
   NextResponse.json({ ok: false, error }, { status });
 
 const buildConfirmUrl = (token: string) =>
-  `${EMAIL_CONFIG.baseUrl}/api/blog/confirm?token=${encodeURIComponent(token)}`;
+  `${EMAIL_CONFIG.baseUrl}/blog/confirm?token=${encodeURIComponent(token)}`;
 
 export async function POST(req: Request) {
   let raw: unknown;

--- a/src/app/api/blog/unsubscribe/route.ts
+++ b/src/app/api/blog/unsubscribe/route.ts
@@ -5,73 +5,23 @@ import { unsubscribeByToken } from '@/libs/subscribers';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-// Two-way unsubscribe — GET for the one-click link in every email, POST for
-// the RFC 8058 `List-Unsubscribe=One-Click` header Gmail/Apple Mail honor.
-// Both honor the token immediately without an interstitial click; the page
-// the user lands on is just a confirmation render.
+// Two-way unsubscribe.
+//
+// GET → 308 redirect to /blog/unsubscribe (so users get the styled page in
+// the BlogTemplate shell, not an inline HTML stub). The token survives the
+// redirect untouched.
+//
+// POST → RFC 8058 one-click. Gmail and Apple Mail call this from inbox UI
+// when the user hits the "Unsubscribe" button next to the sender name. We
+// honor it immediately and reply with 200; no body or HTML needed.
 
-const renderPage = (kind: 'unsubscribed' | 'invalid'): Response => {
-  const isOk = kind === 'unsubscribed';
-  const title = isOk ? 'Inscrição cancelada' : 'Link inválido';
-  const heading = isOk
-    ? 'Pronto, removemos seu e-mail'
-    : 'Esse link não funciona mais';
-  const body = isOk
-    ? 'Você não vai receber mais e-mails nossos a partir de agora. Se mudou de ideia, é só assinar de novo no blog quando quiser.'
-    : 'O link pode ter expirado ou sido digitado errado. Se você ainda quer parar de receber, abra um e-mail nosso recente e use o link de "Cancelar inscrição" no rodapé.';
-
-  const html = `<!doctype html>
-<html lang="pt-BR">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="robots" content="noindex" />
-  <title>${title} — Agility Creative</title>
-  <style>
-    :root { color-scheme: light; }
-    * { box-sizing: border-box; }
-    html, body { margin: 0; background: #fafaf9; color: #1c1917; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, "Helvetica Neue", Arial, sans-serif; }
-    .wrap { max-width: 480px; margin: 0 auto; padding: 80px 24px 64px; }
-    .eyebrow { font-size: 11px; font-weight: 600; letter-spacing: 0.22em; text-transform: uppercase; color: #78716c; display: inline-flex; gap: 12px; align-items: center; margin: 0 0 20px; }
-    .eyebrow::before { content: ""; width: 32px; height: 1px; background: #a8a29e; display: inline-block; }
-    h1 { margin: 0 0 16px; font-size: 32px; line-height: 1.15; letter-spacing: -0.02em; font-weight: 600; }
-    p.lede { margin: 0 0 32px; color: #57534e; line-height: 1.6; font-size: 16px; }
-    .cta { display: inline-flex; align-items: center; gap: 8px; padding: 12px 20px; border-radius: 999px; background: #1c1917; color: #fafaf9; text-decoration: none; font-weight: 500; font-size: 14px; }
-    footer { margin-top: 48px; color: #a8a29e; font-size: 12px; }
-    footer a { color: inherit; text-decoration: underline; }
-  </style>
-</head>
-<body>
-  <main class="wrap">
-    <p class="eyebrow">${isOk ? 'Inscrição cancelada' : 'Algo deu errado'}</p>
-    <h1>${heading}</h1>
-    <p class="lede">${body}</p>
-    <a class="cta" href="/blog">Voltar para o blog →</a>
-    <footer>
-      <p>Agility Creative · <a href="/">agilitycreative.com</a></p>
-    </footer>
-  </main>
-</body>
-</html>`;
-
-  return new NextResponse(html, {
-    status: isOk ? 200 : 400,
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'private, no-store',
-    },
-  });
-};
-
-export async function GET(req: Request) {
-  const token = new URL(req.url).searchParams.get('token') ?? '';
-  const result = await unsubscribeByToken(token);
-  return renderPage(result.ok ? 'unsubscribed' : 'invalid');
+export function GET(req: Request) {
+  const url = new URL(req.url);
+  const target = new URL('/blog/unsubscribe', url.origin);
+  target.search = url.search;
+  return NextResponse.redirect(target, 308);
 }
 
-// RFC 8058 one-click POST — Gmail and Apple Mail fire this when the user hits
-// the "Unsubscribe" button in their inbox UI. No HTML response needed; the
-// mail client only checks the HTTP status.
 export async function POST(req: Request) {
   const token = new URL(req.url).searchParams.get('token') ?? '';
   const result = await unsubscribeByToken(token);

--- a/src/components/blog/SubscribeForm.tsx
+++ b/src/components/blog/SubscribeForm.tsx
@@ -12,6 +12,11 @@ type SubscribeFormProps = {
   source?: string;
 };
 
+// Server should answer the subscribe POST well under a second. If we don't
+// hear back within 5s, treat it as a failure — the user shouldn't be left
+// staring at a spinner forever (Resend timeout, cold start, dropped connection).
+const SUBMIT_TIMEOUT_MS = 5000;
+
 const COPY = {
   eyebrow: 'Receba no e-mail',
   title: 'Novos artigos toda semana',
@@ -20,10 +25,15 @@ const COPY = {
   emailLabel: 'Seu melhor e-mail',
   cta: 'Assinar',
   ctaLoading: 'Enviando…',
-  successTitle: 'Falta um clique',
-  successBody:
-    'Mandamos um e-mail de confirmação. Abra sua caixa de entrada e confirme para começar a receber.',
+  successTitle: 'Falta um clique para confirmar',
+  successBodyStrong: 'Abra seu e-mail agora e clique em',
+  successBodyButton: 'Confirmar inscrição',
+  successBodyTail:
+    '. Sem esse clique a inscrição não vale — exigência da LGPD e dos provedores de e-mail.',
+  successFootnote:
+    'Não chegou em alguns minutos? Confira a pasta de spam ou tente assinar de novo.',
   errorGeneric: 'Algo deu errado. Tente de novo em alguns minutos.',
+  errorTimeout: 'A confirmação demorou demais. Tente de novo.',
   invalidEmail: 'Esse e-mail parece inválido.',
   privacy: 'Você pode cancelar a inscrição a qualquer momento.',
 };
@@ -43,11 +53,16 @@ const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
       return;
     }
     setState({ kind: 'submitting' });
+    // Hard timeout via AbortController — without it the UI stays in
+    // "Enviando…" indefinitely if the server hangs or the network drops.
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), SUBMIT_TIMEOUT_MS);
     try {
       const res = await fetch('/api/blog/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: trimmed, source, locale: 'pt-BR' }),
+        signal: controller.signal,
       });
       if (!res.ok) {
         const detail: { error?: string } = await res.json().catch(() => ({}));
@@ -61,8 +76,14 @@ const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
       }
       setState({ kind: 'success' });
       setEmail('');
-    } catch {
-      setState({ kind: 'error', message: COPY.errorGeneric });
+    } catch (err) {
+      const aborted = err instanceof DOMException && err.name === 'AbortError';
+      setState({
+        kind: 'error',
+        message: aborted ? COPY.errorTimeout : COPY.errorGeneric,
+      });
+    } finally {
+      window.clearTimeout(timeoutId);
     }
   };
 
@@ -71,13 +92,21 @@ const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
       <section className="mx-auto my-20 max-w-3xl rounded-3xl border border-stone-200/70 bg-white p-10 text-center shadow-[0_1px_2px_rgba(0,0,0,0.02)] sm:p-14">
         <p className="mb-4 inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary">
           <span aria-hidden className="h-px w-8 bg-primary" />
-          {COPY.eyebrow}
+          Verifique seu e-mail
         </p>
         <h2 className="text-2xl font-semibold leading-tight tracking-[-0.02em] text-stone-900 md:text-3xl">
           {COPY.successTitle}
         </h2>
-        <p className="mx-auto mt-4 max-w-md text-[15px] leading-relaxed text-stone-500">
-          {COPY.successBody}
+        <p className="mx-auto mt-4 max-w-lg text-[15px] leading-relaxed text-stone-600">
+          {COPY.successBodyStrong}
+          {' '}
+          <span className="rounded-md bg-stone-900 px-2 py-0.5 text-[13px] font-medium text-stone-50">
+            {COPY.successBodyButton}
+          </span>
+          {COPY.successBodyTail}
+        </p>
+        <p className="mx-auto mt-5 max-w-md text-[12px] leading-relaxed text-stone-400">
+          {COPY.successFootnote}
         </p>
       </section>
     );

--- a/src/libs/email/notifyNewPost.ts
+++ b/src/libs/email/notifyNewPost.ts
@@ -8,7 +8,14 @@ const PER_SEND_DELAY_MS = 110; // 9 sends/sec → safely under Resend's 10/sec c
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
-const buildUnsubscribeUrl = (token: string) =>
+// The user-facing unsubscribe page. RFC 8058 one-click POSTs to the API
+// route directly (see the List-Unsubscribe-Post header below); only this URL
+// is what's rendered when the link is clicked normally.
+const buildUnsubscribePageUrl = (token: string) =>
+  `${EMAIL_CONFIG.baseUrl}/blog/unsubscribe?token=${encodeURIComponent(token)}`;
+
+// The RFC 8058 one-click endpoint Gmail/Apple Mail POST to from inbox UI.
+const buildUnsubscribePostUrl = (token: string) =>
   `${EMAIL_CONFIG.baseUrl}/api/blog/unsubscribe?token=${encodeURIComponent(token)}`;
 
 const buildPostUrl = (slug: string) => `${EMAIL_CONFIG.baseUrl}/blog/${slug}`;
@@ -45,7 +52,8 @@ export const notifyNewPost = async (post: BlogPost): Promise<NotifyResult> => {
   };
 
   for (const sub of subscribers) {
-    const unsubscribeUrl = buildUnsubscribeUrl(sub.unsubscribeToken);
+    const unsubscribePageUrl = buildUnsubscribePageUrl(sub.unsubscribeToken);
+    const unsubscribePostUrl = buildUnsubscribePostUrl(sub.unsubscribeToken);
     const { subject, html, text } = buildNewPostEmail({
       title: post.title,
       excerpt: post.excerpt,
@@ -53,7 +61,7 @@ export const notifyNewPost = async (post: BlogPost): Promise<NotifyResult> => {
       coverImage: post.coverImage,
       coverAlt: post.coverAlt,
       postUrl: buildPostUrl(post.slug),
-      unsubscribeUrl,
+      unsubscribeUrl: unsubscribePageUrl,
     });
 
     const send = await sendEmail({
@@ -62,9 +70,11 @@ export const notifyNewPost = async (post: BlogPost): Promise<NotifyResult> => {
       html,
       text,
       headers: {
-        // Both forms — Gmail/Apple Mail accept either; some legacy clients
-        // only look at <…> URI form, others want mailto:.
-        'List-Unsubscribe': `<${unsubscribeUrl}>, <mailto:${EMAIL_CONFIG.replyTo}?subject=unsubscribe>`,
+        // List-Unsubscribe carries BOTH the human-facing page URL (clicked
+        // from the email footer) and the one-click POST endpoint Gmail/Apple
+        // Mail invoke from the inbox UI. mailto: is the legacy fallback for
+        // ancient clients.
+        'List-Unsubscribe': `<${unsubscribePostUrl}>, <${unsubscribePageUrl}>, <mailto:${EMAIL_CONFIG.replyTo}?subject=unsubscribe>`,
         // RFC 8058 — Gmail's "Unsubscribe" button needs this to one-click.
         'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
       },


### PR DESCRIPTION
## What changed

### 1. 5-second timeout on the subscribe form
The button could spin forever if Resend hung, the network dropped, or the route cold-started slowly. Now `SubscribeForm` aborts with an `AbortController` after **5s** and shows a dedicated "A confirmação demorou demais. Tente de novo." error. Timer is cleared on success/error.

### 2. Success copy makes the confirm step impossible to miss
- New eyebrow: **"Verifique seu e-mail"**
- New headline: **"Falta um clique para confirmar"**
- Body now references the literal **`Confirmar inscrição`** button label from the email (rendered as a pill so the visual matches what they'll see in their inbox).
- Adds a soft "Não chegou? Confira o spam ou tente de novo" footnote.
- Mentions LGPD/provider requirement to explain *why* the confirm matters.

### 3. Dedicated `/blog/confirm` and `/blog/unsubscribe` pages
Replaces the inline-HTML responses from the API routes with proper App Router pages that share `BlogTemplate` (header, footer, stone palette, fonts). Both:
- Use `searchParams` to read the token (server component — no client-side flash).
- Render `BlogHero` for the headline/subtitle so visual hierarchy matches the rest of `/blog`.
- Distinguish first-time vs. idempotent ("already confirmed" / "already unsubscribed") states.
- `robots: { index: false, follow: false }` — these are transactional landing pages, not content.

The unsubscribe page also:
- Offers `hi@agilitycreative.com` as a fallback in the error path.
- Asks for a one-line reason on success (helps tune what we send without a survey).

### 4. Legacy API routes redirect to the new pages
`GET /api/blog/confirm` and `GET /api/blog/unsubscribe` now **308** to the new page URLs, preserving the `?token=` query string. Any confirmation email sent before this PR still works.

`POST /api/blog/unsubscribe` is **unchanged** — RFC 8058 one-click for Gmail/Apple Mail's inbox-UI Unsubscribe button stays at the API URL.

### 5. `List-Unsubscribe` header now carries both URLs
Every new-post email sends `List-Unsubscribe: <api-post-url>, <page-url>, <mailto>` — the POST URL for one-click, the page URL for the email-footer link, and `mailto:hi@agilitycreative.com?subject=unsubscribe` as the legacy fallback. `List-Unsubscribe-Post: List-Unsubscribe=One-Click` unchanged.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 141/141 across 25 files
- [x] Local smoke:
  - `/blog/confirm` (no token) → 200, renders styled "esse link não funciona" variant
  - `/blog/unsubscribe` (no token) → same
  - `/api/blog/confirm?token=abc` → **308** → `/blog/confirm?token=abc`
  - `/api/blog/unsubscribe?token=abc` (GET) → 308
  - `/api/blog/unsubscribe?token=abc` (POST) → 400 `invalid_token`
- [ ] Prod (after merge): subscribe → confirmation email → click confirm link → land on `/blog/confirm` styled success page

## Note on the older PR
The original confirm/unsubscribe inline HTML pages were good as a v1 but felt disconnected from the rest of the site — different fonts, no header, no footer. The new pages slot into `BlogTemplate` so the journey from "click subscribe" → "check email" → "click confirm" → "land on a page that matches" is visually consistent.