### PR TITLE
feat(blog): nested article urls, categories hub, header dropdown, article newsletter

### DIFF
--- a/bot/historico.json
+++ b/bot/historico.json
@@ -13,6 +13,13 @@
       "title": "Pela primeira vez, os robôs de IA navegam mais que nós na internet",
       "url": "https://www.agilitycreative.com/blog/bots-de-ia-superam-humanos-no-trafego-da-internet",
       "category": "Inteligência Artificial"
+    },
+    {
+      "date": "2026-06-07",
+      "slug": "amazon-comeca-testes-da-alexa-plus-no-brasil",
+      "title": "Alexa+ chega ao Brasil em teste: o que muda na assistente turbinada por IA",
+      "url": "https://www.agilitycreative.com/blog/amazon-comeca-testes-da-alexa-plus-no-brasil",
+      "category": "Inteligência Artificial"
     }
   ],
   "links_lidos": [
@@ -42,6 +49,18 @@
     "https://tecnoblog.net/noticias/gigantes-reclamam-que-tokens-de-ia-custam-mais-que-funcionarios/",
     "https://olhardigital.com.br/2026/05/28/inteligencia-artificial/filme-de-us-2-mil-produzido-com-ia-estreia-em-festival-de-cinema-nos-eua",
     "https://olhardigital.com.br/2026/06/03/inteligencia-artificial/empresas-ainda-nao-sabem-transformar-ganhos-da-ia-em-resultados-diz-relatorio",
-    "https://olhardigital.com.br/2026/06/03/inteligencia-artificial/europa-mira-autonomia-digital-com-novo-pacote-de-tecnologia-e-ia"
+    "https://olhardigital.com.br/2026/06/03/inteligencia-artificial/europa-mira-autonomia-digital-com-novo-pacote-de-tecnologia-e-ia",
+    "https://tecnoblog.net/noticias/brasil-comeca-a-testar-alexa-mais-inteligente-turbinada-por-ia/",
+    "https://tecnoblog.net/noticias/inteligencia-artificial-gera-odio-e-vaia-entre-jovens-universitarios/",
+    "https://tecnoblog.net/noticias/google-lanca-agente-autonomo-do-gemini-capaz-de-fazer-pedidos-no-android/",
+    "https://tecnoblog.net/noticias/senador-quer-dar-metade-das-empresas-de-ia-ao-povo-americano/",
+    "https://tecnoblog.net/noticias/faxina-gratis-vira-moeda-de-troca-para-empresa-de-ia/",
+    "https://tecnoblog.net/noticias/pesquisa-mostra-que-chatbots-estao-errados-em-60-do-tempo/",
+    "https://olhardigital.com.br/2026/05/27/inteligencia-artificial/o-gemini-do-google-agora-executa-tarefas-observando-sua-casa-pelas-cameras-de-seguranca/",
+    "https://olhardigital.com.br/2026/06/03/internet-e-redes-sociais/google-permitira-que-sites-parem-de-aparecer-nos-resultados-de-busca-com-ia",
+    "https://olhardigital.com.br/2026/05/19/reviews/spark-omni-veja-tudo-o-que-o-google-anunciou-no-i-o-2026/",
+    "https://olhardigital.com.br/2026/05/04/robotica/nova-ia-permite-que-robos-dobrem-roupa-e-organizem-objetos-mais-rapido-que-humanos/",
+    "https://olhardigital.com.br/2026/02/10/inteligencia-artificial/dona-do-tiktok-lanca-ia-que-gera-videos-e-faz-mercado-disparar-na-china/",
+    "https://olhardigital.com.br/2026/02/25/internet-e-redes-sociais/gemini-vai-chamar-uber-e-fazer-pedidos-no-delivery-por-voce/"
   ]
 }

--- a/src/app/[locale]/blog/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[category]/[slug]/page.tsx
@@ -1,9 +1,16 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import { notFound } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 
-import { BlogArticleBody, BlogHero } from '@/components/blog';
+import {
+  BlogArticleBody,
+  blogArticlePath,
+  blogCategoryPath,
+  BlogHero,
+  postCategorySlug,
+  SubscribeForm,
+} from '@/components/blog';
 import { getPostsSafe } from '@/libs/blogStore';
 import { Link } from '@/libs/i18nNavigation';
 import { isPublished } from '@/types/blog';
@@ -14,6 +21,7 @@ import { buildDefaultLocaleAlternates, localizedUrl, ogLocale } from '@/utils/se
 export const dynamic = 'force-dynamic';
 
 type Params = {
+  category: string;
   slug: string;
   locale: string;
 };
@@ -21,10 +29,15 @@ type Params = {
 export async function generateMetadata(props: {
   params: Promise<Params>;
 }): Promise<Metadata> {
-  const { slug } = await props.params;
+  const { category, slug } = await props.params;
   const posts = await getPostsSafe();
   const post = posts.find(item => item.slug === slug);
-  const alternates = buildDefaultLocaleAlternates(`/blog/${slug}`, { withRssFeed: true });
+  // Canonical URL always uses the post's true category slug, even if the
+  // request came in under a stale or wrong category (we redirect those — see
+  // page body — but metadata must still point at the canonical path).
+  const canonicalCategory = post ? postCategorySlug(post) : category;
+  const canonicalPath = `/blog/${canonicalCategory}/${slug}`;
+  const alternates = buildDefaultLocaleAlternates(canonicalPath, { withRssFeed: true });
   const title = post?.title ?? slug;
   const description = post?.excerpt ?? '';
   const ogImage = post?.coverImage;
@@ -59,19 +72,28 @@ export async function generateMetadata(props: {
 }
 
 const BlogArticlePage = async (props: { params: Promise<Params> }) => {
-  const { slug } = await props.params;
+  const { category, slug } = await props.params;
   // Blog is pt-BR only — pin locale regardless of `[locale]` segment.
   const safeLocale = AppConfig.defaultLocale;
   const t = await getTranslations({ locale: safeLocale, namespace: 'BlogDetail' });
   const posts = await getPostsSafe();
   const existing = posts.find(item => item.slug === slug);
+
   // Real 404 (not a soft 200 with a "not found" message) for both missing
-  // slugs and drafts — keeps unpublished URLs out of search indexes and
-  // matches the category page's behavior.
+  // slugs and drafts — keeps unpublished URLs out of search indexes.
   if (!existing || !isPublished(existing)) {
     notFound();
   }
   const post = existing;
+
+  // The category segment is part of the URL but only the slug uniquely
+  // identifies the post. If the visitor arrived under a stale category
+  // (renamed, typo, old share), permanent-redirect them to the canonical
+  // URL so SEO equity consolidates on one path.
+  const canonicalCategorySlug = postCategorySlug(post);
+  if (canonicalCategorySlug !== category) {
+    permanentRedirect(blogArticlePath(post));
+  }
 
   const dateLabel = new Intl.DateTimeFormat(safeLocale === 'pt-BR' ? 'pt-BR' : 'en-US', {
     year: 'numeric',
@@ -79,6 +101,7 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
     day: 'numeric',
   }).format(new Date(post.publishedAt));
 
+  const articleUrl = localizedUrl(safeLocale, blogArticlePath(post));
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
@@ -90,9 +113,10 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
     'author': post.author
       ? { '@type': 'Person', 'name': post.author.name }
       : undefined,
+    'articleSection': post.category,
     'mainEntityOfPage': {
       '@type': 'WebPage',
-      '@id': localizedUrl(safeLocale, `/blog/${slug}`),
+      '@id': articleUrl,
     },
   };
 
@@ -127,6 +151,16 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
     </>
   );
 
+  // Breadcrumb: Blog → Category → Article. The category crumb is the new
+  // navigation surface — readers can click it to see siblings.
+  const breadcrumbs = [
+    { label: t('breadcrumbBlog'), href: '/blog' },
+    ...(post.category
+      ? [{ label: post.category, href: blogCategoryPath(canonicalCategorySlug) }]
+      : []),
+    { label: post.title },
+  ];
+
   return (
     <>
       <BlogHero
@@ -134,10 +168,7 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
         title={post.title}
         subtitle={post.excerpt}
         meta={heroMeta}
-        breadcrumbs={[
-          { label: t('breadcrumbBlog'), href: '/blog' },
-          { label: post.title },
-        ]}
+        breadcrumbs={breadcrumbs}
       />
 
       <article className="mx-auto max-w-[720px] px-5 py-20 sm:px-8 md:py-28">
@@ -180,6 +211,12 @@ const BlogArticlePage = async (props: { params: Promise<Params> }) => {
           </Link>
         </div>
       </article>
+
+      {/* Newsletter CTA inside the article column so it reads as a natural
+          end-of-piece prompt, not a separate site-wide footer block. */}
+      <div className="mx-auto max-w-3xl px-5 pb-8 sm:px-8">
+        <SubscribeForm source={`blog-article:${post.slug}`} />
+      </div>
 
       <script
         type="application/ld+json"

--- a/src/app/[locale]/blog/[category]/page.tsx
+++ b/src/app/[locale]/blog/[category]/page.tsx
@@ -1,0 +1,186 @@
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+
+import type { BlogCardItem } from '@/components/blog';
+import {
+  blogArticlePath,
+  blogCategoryPath,
+  BlogHero,
+  BlogIndex,
+  findCategoryBySlug,
+  getOrderedCategories,
+  slugifyCategory,
+} from '@/components/blog';
+import { getPostsSafe } from '@/libs/blogStore';
+import { isPublished } from '@/types/blog';
+import { AppConfig } from '@/utils/AppConfig';
+import { getBaseUrl } from '@/utils/Helpers';
+import { buildDefaultLocaleAlternates, localizedUrl, ogLocale } from '@/utils/seo';
+
+export const dynamic = 'force-dynamic';
+
+type Params = {
+  category: string;
+  locale: string;
+};
+
+// `/blog/[category]` is a dual-purpose route:
+//
+// 1. If the segment matches a real CATEGORY → render the category page
+//    (this is the canonical URL — was previously `/blog/category/<slug>`).
+//
+// 2. If it matches an old ARTICLE slug → 308 permanent-redirect to
+//    `/blog/<category>/<slug>` (the new canonical article URL).
+//    Catches every old indexed/shared URL and consolidates SEO equity.
+//
+// 3. Otherwise → 404.
+//
+// Static `/blog/categories/page.tsx` takes precedence at the same depth, so
+// the categories hub is unaffected.
+
+export async function generateMetadata(props: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { category: categorySegment } = await props.params;
+  const safeLocale = AppConfig.defaultLocale;
+  const posts = await getPostsSafe();
+  const category = findCategoryBySlug(posts, categorySegment);
+  const t = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
+  const alternates = buildDefaultLocaleAlternates(
+    blogCategoryPath(categorySegment),
+    { withRssFeed: true },
+  );
+
+  if (!category) {
+    return {
+      metadataBase: new URL(getBaseUrl()),
+      title: t('notFound'),
+      alternates,
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const title = `${t('titlePrefix')} ${category.label}`.trim();
+  const description = t('metaDescription', { category: category.label });
+
+  return {
+    metadataBase: new URL(getBaseUrl()),
+    title,
+    description,
+    keywords: [category.label, 'blog', 'agility creative'],
+    alternates,
+    openGraph: {
+      title,
+      description,
+      url: alternates.canonical,
+      siteName: AppConfig.name,
+      locale: ogLocale(safeLocale),
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+  };
+}
+
+const BlogCategoryOrLegacyArticlePage = async (props: { params: Promise<Params> }) => {
+  const { category: categorySegment } = await props.params;
+  const safeLocale = AppConfig.defaultLocale;
+  const posts = await getPostsSafe();
+
+  // Branch 2: legacy article URL — permanent-redirect to canonical.
+  const matchingPost = posts.find(post => post.slug === categorySegment);
+  if (matchingPost) {
+    permanentRedirect(blogArticlePath(matchingPost));
+  }
+
+  // Branch 1: category page.
+  const category = findCategoryBySlug(posts, categorySegment);
+  if (!category) {
+    notFound();
+  }
+
+  const tBlog = await getTranslations({ locale: safeLocale, namespace: 'BlogPage' });
+  const tCategory = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
+
+  const sortedPosts = posts
+    .filter(post =>
+      isPublished(post)
+      && post.category
+      && slugifyCategory(post.category) === categorySegment,
+    )
+    .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+
+  const items: BlogCardItem[] = sortedPosts.map(post => ({
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    coverImage: post.coverImage,
+    coverAlt: post.coverAlt,
+    category: post.category,
+    publishedAt: post.publishedAt,
+    readingTimeMinutes: post.readingTimeMinutes,
+  }));
+
+  const categories = getOrderedCategories(posts.filter(isPublished));
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    'name': `${tCategory('titlePrefix')} ${category.label}`,
+    'description': tCategory('metaDescription', { category: category.label }),
+    'url': localizedUrl(safeLocale, blogCategoryPath(categorySegment)),
+    'inLanguage': safeLocale,
+    'mainEntity': {
+      '@type': 'ItemList',
+      'itemListElement': items.map((item, index) => ({
+        '@type': 'ListItem',
+        'position': index + 1,
+        'url': localizedUrl(safeLocale, blogArticlePath(item)),
+        'name': item.title,
+      })),
+    },
+  };
+
+  return (
+    <>
+      <BlogHero
+        eyebrow={`${tCategory('eyebrowPrefix')} · ${category.label}`}
+        title={(
+          <>
+            {tCategory('titlePrefix')}
+            {' '}
+            <span className="text-primary">{category.label}</span>
+          </>
+        )}
+        subtitle={tCategory('subtitle', { category: category.label })}
+        breadcrumbs={[
+          { label: tCategory('breadcrumbBlog'), href: '/blog' },
+          { label: category.label },
+        ]}
+      />
+
+      <BlogIndex
+        items={items}
+        categories={categories}
+        activeSlug={categorySegment}
+        locale={safeLocale}
+        allLabel={tBlog('allLabel')}
+        readArticleLabel={tBlog('readArticle')}
+        emptyLabel={tBlog('empty')}
+        moreLabel={tBlog('more')}
+      />
+
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/dom-no-dangerously-set-innerhtml
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </>
+  );
+};
+
+export default BlogCategoryOrLegacyArticlePage;

--- a/src/app/[locale]/blog/categories/page.tsx
+++ b/src/app/[locale]/blog/categories/page.tsx
@@ -1,0 +1,147 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+
+import {
+  blogCategoriesPath,
+  blogCategoryPath,
+  BlogHero,
+  getOrderedCategories,
+  slugifyCategory,
+} from '@/components/blog';
+import { getPostsSafe } from '@/libs/blogStore';
+import { Link } from '@/libs/i18nNavigation';
+import { isPublished } from '@/types/blog';
+import { AppConfig } from '@/utils/AppConfig';
+import { getBaseUrl } from '@/utils/Helpers';
+import { buildDefaultLocaleAlternates, localizedUrl, ogLocale } from '@/utils/seo';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const safeLocale = AppConfig.defaultLocale;
+  const t = await getTranslations({ locale: safeLocale, namespace: 'BlogCategories' });
+  const alternates = buildDefaultLocaleAlternates(blogCategoriesPath(), { withRssFeed: true });
+
+  return {
+    metadataBase: new URL(getBaseUrl()),
+    title: t('metaTitle'),
+    description: t('metaDescription'),
+    keywords: ['blog', 'categorias', 'agility creative'],
+    alternates,
+    openGraph: {
+      title: t('metaTitle'),
+      description: t('metaDescription'),
+      url: alternates.canonical,
+      siteName: AppConfig.name,
+      locale: ogLocale(safeLocale),
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: t('metaTitle'),
+      description: t('metaDescription'),
+    },
+  };
+}
+
+const BlogCategoriesPage = async () => {
+  const safeLocale = AppConfig.defaultLocale;
+  const t = await getTranslations({ locale: safeLocale, namespace: 'BlogCategories' });
+  const tCat = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
+  const tNav = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
+
+  const posts = (await getPostsSafe()).filter(isPublished);
+  // Same ordering rule as the index — first-seen wins, dedup by slug.
+  const categories = getOrderedCategories(posts);
+  const postsByCategory = new Map<string, number>();
+  for (const post of posts) {
+    if (!post.category) {
+      continue;
+    }
+    const key = slugifyCategory(post.category);
+    postsByCategory.set(key, (postsByCategory.get(key) ?? 0) + 1);
+  }
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    'name': t('metaTitle'),
+    'description': t('metaDescription'),
+    'url': localizedUrl(safeLocale, blogCategoriesPath()),
+    'inLanguage': safeLocale,
+    'mainEntity': {
+      '@type': 'ItemList',
+      'itemListElement': categories.map((category, index) => ({
+        '@type': 'ListItem',
+        'position': index + 1,
+        'name': category.label,
+        'url': localizedUrl(safeLocale, blogCategoryPath(category)),
+      })),
+    },
+  };
+
+  return (
+    <>
+      <BlogHero
+        eyebrow={t('eyebrow')}
+        title={t('title')}
+        subtitle={t('subtitle')}
+        breadcrumbs={[
+          { label: tNav('breadcrumbBlog'), href: '/blog' },
+          { label: t('eyebrow') },
+        ]}
+      />
+
+      <section className="mx-auto max-w-6xl px-5 pb-28 pt-12 sm:px-8 md:pb-36 md:pt-16">
+        <ul className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {categories.map((category) => {
+            const count = postsByCategory.get(category.slug) ?? 0;
+            const countLabel
+              = count === 1
+                ? t('postCountOne', { count })
+                : t('postCountOther', { count });
+            return (
+              <li key={category.slug}>
+                <Link
+                  href={blogCategoryPath(category)}
+                  className="group flex h-full flex-col gap-5 rounded-2xl border border-stone-200/70 bg-white p-7 shadow-[0_1px_2px_rgba(0,0,0,0.02)] transition-all duration-300 hover:-translate-y-0.5 hover:border-stone-300/70 hover:shadow-[0_12px_28px_-12px_rgba(0,0,0,0.12),0_4px_10px_-6px_rgba(0,0,0,0.06)]"
+                >
+                  <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+                    <span>{t('eyebrow')}</span>
+                    <span className="text-stone-400">{countLabel}</span>
+                  </div>
+                  <h2 className="text-[22px] font-semibold leading-tight tracking-[-0.01em] text-stone-900 transition-colors group-hover:text-primary">
+                    {category.label}
+                  </h2>
+                  <p className="mt-auto text-[13px] leading-relaxed text-stone-500">
+                    {tCat('subtitle', { category: category.label })}
+                  </p>
+                  <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-900">
+                    {t('exploreLink')}
+                    <span
+                      aria-hidden
+                      className="inline-flex size-7 items-center justify-center rounded-full bg-stone-900 text-stone-50 transition-transform duration-300 group-hover:translate-x-1"
+                    >
+                      <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <line x1="5" y1="12" x2="19" y2="12" />
+                        <polyline points="12 5 19 12 12 19" />
+                      </svg>
+                    </span>
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/dom-no-dangerously-set-innerhtml
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </>
+  );
+};
+
+export default BlogCategoriesPage;

--- a/src/app/[locale]/blog/category/[slug]/page.tsx
+++ b/src/app/[locale]/blog/category/[slug]/page.tsx
@@ -1,161 +1,18 @@
-import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
-import { getTranslations } from 'next-intl/server';
+import { permanentRedirect } from 'next/navigation';
 
-import type { BlogCardItem } from '@/components/blog';
-import {
-  BlogHero,
-  BlogIndex,
-  findCategoryBySlug,
-  getOrderedCategories,
-  slugifyCategory,
-} from '@/components/blog';
-import { getPostsSafe } from '@/libs/blogStore';
-import { isPublished } from '@/types/blog';
-import { AppConfig } from '@/utils/AppConfig';
-import { getBaseUrl } from '@/utils/Helpers';
-import { buildDefaultLocaleAlternates, localizedUrl, ogLocale } from '@/utils/seo';
+import { blogCategoryPath } from '@/components/blog';
 
 export const dynamic = 'force-dynamic';
 
-type Params = {
-  slug: string;
-  locale: string;
-};
+type Params = { slug: string };
 
-export async function generateMetadata(props: {
-  params: Promise<Params>;
-}): Promise<Metadata> {
+// Legacy shim. Category pages moved from `/blog/category/<slug>` to the
+// shorter, dropdown-friendly `/blog/<slug>`. Any indexed or shared URL on
+// the old path gets a permanent redirect so SEO equity follows.
+//
+// Generates a runtime metadata noop — there's no body to render, the
+// permanent-redirect returns 308 before metadata matters.
+export default async function BlogCategoryLegacyPage(props: { params: Promise<Params> }) {
   const { slug } = await props.params;
-  const safeLocale = AppConfig.defaultLocale;
-  const posts = await getPostsSafe();
-  const category = findCategoryBySlug(posts, slug);
-  const t = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
-  const alternates = buildDefaultLocaleAlternates(`/blog/category/${slug}`, { withRssFeed: true });
-
-  if (!category) {
-    return {
-      metadataBase: new URL(getBaseUrl()),
-      title: t('notFound'),
-      alternates,
-      robots: { index: false, follow: false },
-    };
-  }
-
-  const title = `${t('titlePrefix')} ${category.label}`.trim();
-  const description = t('metaDescription', { category: category.label });
-
-  return {
-    metadataBase: new URL(getBaseUrl()),
-    title,
-    description,
-    keywords: [category.label, 'blog', 'agility creative'],
-    alternates,
-    openGraph: {
-      title,
-      description,
-      url: alternates.canonical,
-      siteName: AppConfig.name,
-      locale: ogLocale(safeLocale),
-      type: 'website',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-    },
-  };
+  permanentRedirect(blogCategoryPath(slug));
 }
-
-const BlogCategoryPage = async (props: { params: Promise<Params> }) => {
-  const { slug } = await props.params;
-  // Blog is pt-BR only — pin locale regardless of `[locale]` segment.
-  const safeLocale = AppConfig.defaultLocale;
-  const posts = await getPostsSafe();
-  const category = findCategoryBySlug(posts, slug);
-
-  if (!category) {
-    notFound();
-  }
-
-  const tBlog = await getTranslations({ locale: safeLocale, namespace: 'BlogPage' });
-  const tCategory = await getTranslations({ locale: safeLocale, namespace: 'BlogCategory' });
-
-  const sortedPosts = posts
-    .filter(post =>
-      isPublished(post)
-      && post.category
-      && slugifyCategory(post.category) === slug,
-    )
-    .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
-
-  const items: BlogCardItem[] = sortedPosts.map(post => ({
-    slug: post.slug,
-    title: post.title,
-    excerpt: post.excerpt,
-    coverImage: post.coverImage,
-    coverAlt: post.coverAlt,
-    category: post.category,
-    publishedAt: post.publishedAt,
-    readingTimeMinutes: post.readingTimeMinutes,
-  }));
-
-  const categories = getOrderedCategories(posts.filter(isPublished));
-
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'CollectionPage',
-    'name': `${tCategory('titlePrefix')} ${category.label}`,
-    'description': tCategory('metaDescription', { category: category.label }),
-    'url': localizedUrl(safeLocale, `/blog/category/${slug}`),
-    'inLanguage': safeLocale,
-    'mainEntity': {
-      '@type': 'ItemList',
-      'itemListElement': items.map((item, index) => ({
-        '@type': 'ListItem',
-        'position': index + 1,
-        'url': localizedUrl(safeLocale, `/blog/${item.slug}`),
-        'name': item.title,
-      })),
-    },
-  };
-
-  return (
-    <>
-      <BlogHero
-        eyebrow={`${tCategory('eyebrowPrefix')} · ${category.label}`}
-        title={(
-          <>
-            {tCategory('titlePrefix')}
-            {' '}
-            <span className="text-primary">{category.label}</span>
-          </>
-        )}
-        subtitle={tCategory('subtitle', { category: category.label })}
-        breadcrumbs={[
-          { label: tCategory('breadcrumbBlog'), href: '/blog' },
-          { label: category.label },
-        ]}
-      />
-
-      <BlogIndex
-        items={items}
-        categories={categories}
-        activeSlug={slug}
-        locale={safeLocale}
-        allLabel={tBlog('allLabel')}
-        readArticleLabel={tBlog('readArticle')}
-        emptyLabel={tBlog('empty')}
-        moreLabel={tBlog('more')}
-      />
-
-      <script
-        type="application/ld+json"
-        // eslint-disable-next-line react/dom-no-dangerously-set-innerhtml
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-    </>
-  );
-};
-
-export default BlogCategoryPage;

--- a/src/app/[locale]/blog/layout.tsx
+++ b/src/app/[locale]/blog/layout.tsx
@@ -1,6 +1,9 @@
 import { setRequestLocale } from 'next-intl/server';
 
+import { getOrderedCategories } from '@/components/blog';
+import { getPostsSafe } from '@/libs/blogStore';
 import BlogTemplate from '@/templates/BlogTemplate';
+import { isPublished } from '@/types/blog';
 
 export default async function Layout(
   props: {
@@ -9,8 +12,12 @@ export default async function Layout(
   },
 ) {
   setRequestLocale((await props.params).locale);
+  // Categories feed the header dropdown. Fetching once at the layout level
+  // keeps every blog page consistent without each page re-querying.
+  const posts = await getPostsSafe();
+  const categories = getOrderedCategories(posts.filter(isPublished));
   return (
-    <BlogTemplate>
+    <BlogTemplate categories={categories}>
       {props.children}
     </BlogTemplate>
   );

--- a/src/app/feed-rss/route.ts
+++ b/src/app/feed-rss/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { blogArticlePath } from '@/components/blog/blogUrls';
 import { getPostsSafe } from '@/libs/blogStore';
 import type { BlogBodyBlock, BlogPost } from '@/types/blog';
 import { isPublished } from '@/types/blog';
@@ -59,7 +60,7 @@ const renderBlockToHtml = (block: BlogBodyBlock): string => {
 };
 
 const renderItem = (post: BlogPost): string => {
-  const link = localizedUrl(AppConfig.defaultLocale, `/blog/${post.slug}`);
+  const link = localizedUrl(AppConfig.defaultLocale, blogArticlePath(post));
   const html = post.body.map(renderBlockToHtml).join('\n');
   const pubDate = new Date(post.publishedAt).toUTCString();
   const category = post.category

--- a/src/app/sitemap-feed/route.ts
+++ b/src/app/sitemap-feed/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { blogArticlePath, blogCategoriesPath, blogCategoryPath, blogIndexPath } from '@/components/blog/blogUrls';
 import { getAllCategorySlugs } from '@/components/blog/categories';
 import portfolioData from '@/data/portfolio.json';
 import { getPostsSafe } from '@/libs/blogStore';
@@ -119,25 +120,37 @@ const buildEntries = async (): Promise<Entry[]> => {
   // Blog is pt-BR only — one row per published post, hreflang locked to the
   // default locale so /en/blog* doesn't get crawled (middleware 308s it back).
   const blogPosts = (await getPostsSafe()).filter(isPublished);
+  const blogIndex = blogIndexPath();
+  const categoriesHub = blogCategoriesPath();
   entries.push({
-    url: localizedUrl(AppConfig.defaultLocale, '/blog'),
+    url: localizedUrl(AppConfig.defaultLocale, blogIndex),
     lastModified: now,
     changeFrequency: 'daily',
     priority: 0.8,
-    alternates: defaultOnlyAlternates('/blog'),
+    alternates: defaultOnlyAlternates(blogIndex),
+  });
+  entries.push({
+    url: localizedUrl(AppConfig.defaultLocale, categoriesHub),
+    lastModified: now,
+    changeFrequency: 'weekly',
+    priority: 0.6,
+    alternates: defaultOnlyAlternates(categoriesHub),
   });
   for (const post of blogPosts) {
-    const blogPath = `/blog/${post.slug}`;
+    // Canonical URL is the new /blog/<category>/<slug> shape. Old
+    // /blog/<slug> URLs are handled by the in-app 308 redirect.
+    const articlePath = blogArticlePath(post);
     entries.push({
-      url: localizedUrl(AppConfig.defaultLocale, blogPath),
+      url: localizedUrl(AppConfig.defaultLocale, articlePath),
       lastModified: new Date(post.updatedAt ?? post.publishedAt),
       changeFrequency: 'monthly',
       priority: 0.7,
-      alternates: defaultOnlyAlternates(blogPath),
+      alternates: defaultOnlyAlternates(articlePath),
     });
   }
   for (const categorySlug of getAllCategorySlugs(blogPosts)) {
-    const categoryPath = `/blog/category/${categorySlug}`;
+    // Category pages moved from /blog/category/<slug> to /blog/<slug>.
+    const categoryPath = blogCategoryPath(categorySlug);
     entries.push({
       url: localizedUrl(AppConfig.defaultLocale, categoryPath),
       lastModified: now,

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 
 import { Link } from '@/libs/i18nNavigation';
 
+import { blogArticlePath } from './blogUrls';
 import { formatShortDate } from './formatDate';
 
 export type BlogCardItem = {
@@ -27,7 +28,7 @@ const BlogCard = ({ item, locale }: BlogCardProps) => {
 
   return (
     <Link
-      href={`/blog/${item.slug}`}
+      href={blogArticlePath(item)}
       className="group flex h-full flex-col gap-6 rounded-2xl border border-stone-200/70 bg-white p-6 shadow-[0_1px_2px_rgba(0,0,0,0.02)] transition-all duration-300 hover:-translate-y-0.5 hover:border-stone-300/70 hover:shadow-[0_12px_28px_-12px_rgba(0,0,0,0.12),0_4px_10px_-6px_rgba(0,0,0,0.06)]"
     >
       <div className="flex items-center gap-2.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-stone-400">

--- a/src/components/blog/BlogCategoryTabs.tsx
+++ b/src/components/blog/BlogCategoryTabs.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 
 import { Link } from '@/libs/i18nNavigation';
 
+import { blogCategoryPath, blogIndexPath } from './blogUrls';
 import type { BlogCategoryRef } from './categories';
 
 type BlogCategoryTabsProps = {
@@ -20,11 +21,11 @@ const BlogCategoryTabs = ({
   allSlug = ALL_SLUG,
 }: BlogCategoryTabsProps) => {
   const items: { slug: string; label: string; href: string }[] = [
-    { slug: allSlug, label: allLabel, href: '/blog' },
+    { slug: allSlug, label: allLabel, href: blogIndexPath() },
     ...categories.map(category => ({
       slug: category.slug,
       label: category.label,
-      href: `/blog/category/${category.slug}`,
+      href: blogCategoryPath(category),
     })),
   ];
 

--- a/src/components/blog/BlogFeaturedCard.tsx
+++ b/src/components/blog/BlogFeaturedCard.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { Link } from '@/libs/i18nNavigation';
 
 import type { BlogCardItem } from './BlogCard';
+import { blogArticlePath } from './blogUrls';
 import { formatShortDate } from './formatDate';
 
 type BlogFeaturedCardProps = {
@@ -18,7 +19,7 @@ const BlogFeaturedCard = ({ item, locale, readArticleLabel }: BlogFeaturedCardPr
 
   return (
     <Link
-      href={`/blog/${item.slug}`}
+      href={blogArticlePath(item)}
       className="group relative grid grid-cols-1 overflow-hidden rounded-3xl border border-stone-200/70 bg-white shadow-[0_1px_2px_rgba(0,0,0,0.02)] transition-all duration-500 hover:-translate-y-0.5 hover:border-stone-300/70 hover:shadow-[0_24px_60px_-20px_rgba(0,0,0,0.18),0_8px_20px_-12px_rgba(0,0,0,0.08)] lg:grid-cols-[1.55fr_1fr]"
     >
       {item.coverImage

--- a/src/components/blog/BlogHeader.tsx
+++ b/src/components/blog/BlogHeader.tsx
@@ -7,12 +7,21 @@ import { useState } from 'react';
 
 import { Link } from '@/libs/i18nNavigation';
 
+import { blogIndexPath } from './blogUrls';
+import type { BlogCategoryRef } from './categories';
+import HeaderCategoriesDropdown from './HeaderCategoriesDropdown';
+
 const HIDE_AFTER = 120;
 const ELEVATE_AFTER = 8;
 
-const BlogHeader = () => {
+type BlogHeaderProps = {
+  categories?: BlogCategoryRef[];
+};
+
+const BlogHeader = ({ categories = [] }: BlogHeaderProps) => {
   const t = useTranslations('Navbar');
   const tBlog = useTranslations('BlogPage');
+  const tHeader = useTranslations('BlogHeader');
   const [hidden, setHidden] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const { scrollY } = useScroll();
@@ -36,24 +45,25 @@ const BlogHeader = () => {
       transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
     >
       <div className="mx-auto flex h-[72px] max-w-6xl items-center justify-between gap-6 px-5 sm:px-8">
-        <Link href="/" className="group flex items-center gap-2.5">
+        <Link href={blogIndexPath()} className="group flex items-center gap-2.5">
           <Image src="/assets/images/logo/logo_symbol_black.svg" alt="Agility" width={26} height={26} />
           <Image src="/assets/images/logo/logo_name_black.svg" alt="Agility" width={82} height={20} className="hidden sm:block" />
         </Link>
 
         <nav className="flex items-center gap-1 sm:gap-1.5">
           <Link
-            href="/blog"
+            href={blogIndexPath()}
             className="rounded-full px-3.5 py-2 text-[13px] font-medium tracking-tight text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900"
           >
             {tBlog('badge')}
           </Link>
-          <Link
-            href="/"
-            className="hidden rounded-full px-3.5 py-2 text-[13px] font-medium tracking-tight text-stone-600 transition-colors hover:bg-stone-100 hover:text-stone-900 sm:inline-block"
-          >
-            {t('home')}
-          </Link>
+
+          <HeaderCategoriesDropdown
+            label={tHeader('categoriesDropdownLabel')}
+            allLabel={tHeader('categoriesDropdownAll')}
+            categories={categories}
+          />
+
           <Link
             href="/#Contato"
             className="ml-1.5 hidden items-center gap-1.5 rounded-full bg-stone-900 px-4 py-2 text-[13px] font-medium tracking-tight text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all hover:bg-stone-800 hover:shadow-[0_4px_12px_rgba(0,0,0,0.12),inset_0_1px_0_rgba(255,255,255,0.08)] sm:inline-flex"

--- a/src/components/blog/HeaderCategoriesDropdown.tsx
+++ b/src/components/blog/HeaderCategoriesDropdown.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import classNames from 'classnames';
+import { useEffect, useId, useRef, useState } from 'react';
+
+import { Link } from '@/libs/i18nNavigation';
+
+import { blogCategoriesPath, blogCategoryPath } from './blogUrls';
+import type { BlogCategoryRef } from './categories';
+
+type HeaderCategoriesDropdownProps = {
+  label: string;
+  allLabel: string;
+  categories: BlogCategoryRef[];
+};
+
+const HeaderCategoriesDropdown = ({
+  label,
+  allLabel,
+  categories,
+}: HeaderCategoriesDropdownProps) => {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const panelId = useId();
+
+  // Click outside / Escape closes the menu. We only attach the listener
+  // when the menu is open so we don't pay the cost on every page.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handlePointer = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node | null;
+      if (!target) {
+        return;
+      }
+      if (
+        buttonRef.current?.contains(target)
+        || panelRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('touchstart', handlePointer);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('touchstart', handlePointer);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen(prev => !prev)}
+        className={classNames(
+          'inline-flex items-center gap-1 rounded-full px-3.5 py-2 text-[13px] font-medium tracking-tight transition-colors',
+          open
+            ? 'bg-stone-100 text-stone-900'
+            : 'text-stone-600 hover:bg-stone-100 hover:text-stone-900',
+        )}
+      >
+        {label}
+        <svg
+          viewBox="0 0 24 24"
+          width="12"
+          height="12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+          className={classNames(
+            'transition-transform duration-200',
+            open ? 'rotate-180' : 'rotate-0',
+          )}
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          id={panelId}
+          role="menu"
+          aria-label={label}
+          className="absolute right-0 top-[calc(100%+8px)] z-50 w-64 origin-top-right overflow-hidden rounded-2xl border border-stone-200/70 bg-white p-1.5 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.18),0_8px_20px_-12px_rgba(0,0,0,0.08)]"
+        >
+          {categories.length === 0
+            ? (
+                <p className="px-3 py-3 text-[12px] text-stone-400">—</p>
+              )
+            : (
+                <ul className="space-y-px">
+                  {categories.map(category => (
+                    <li key={category.slug}>
+                      <Link
+                        href={blogCategoryPath(category)}
+                        role="menuitem"
+                        onClick={() => setOpen(false)}
+                        className="block rounded-lg px-3 py-2 text-[13px] font-medium text-stone-700 transition-colors hover:bg-stone-100 hover:text-stone-900"
+                      >
+                        {category.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+          <div className="my-1.5 h-px bg-stone-200/70" />
+          <Link
+            href={blogCategoriesPath()}
+            role="menuitem"
+            onClick={() => setOpen(false)}
+            className="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-500 transition-colors hover:bg-stone-100 hover:text-stone-900"
+          >
+            {allLabel}
+            <span aria-hidden>→</span>
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HeaderCategoriesDropdown;

--- a/src/components/blog/blogUrls.ts
+++ b/src/components/blog/blogUrls.ts
@@ -1,0 +1,37 @@
+import { slugifyCategory } from './categories';
+
+// Posts without a category are routed under a stable bucket so the URL
+// shape stays consistent. The bot always sets a category, so this is a
+// guard for hand-written edge cases.
+export const UNCATEGORIZED_SLUG = 'sem-categoria';
+
+const toCategorySlug = (category: string | undefined): string => {
+  if (!category) {
+    return UNCATEGORIZED_SLUG;
+  }
+  const slug = slugifyCategory(category);
+  return slug || UNCATEGORIZED_SLUG;
+};
+
+/** `/blog/{category-slug}/{post-slug}` — the canonical article URL. */
+export const blogArticlePath = (post: { slug: string; category?: string }): string =>
+  `/blog/${toCategorySlug(post.category)}/${post.slug}`;
+
+/** `/blog/{category-slug}` — the canonical category index URL. */
+export const blogCategoryPath = (category: string | { slug: string } | undefined): string => {
+  if (!category) {
+    return `/blog/${UNCATEGORIZED_SLUG}`;
+  }
+  const slug = typeof category === 'string' ? toCategorySlug(category) : category.slug;
+  return `/blog/${slug}`;
+};
+
+/** Blog index. */
+export const blogIndexPath = (): string => '/blog';
+
+/** Categories hub (all categories). */
+export const blogCategoriesPath = (): string => '/blog/categories';
+
+/** Resolve the category slug for a post (used by redirect logic on legacy URLs). */
+export const postCategorySlug = (post: { category?: string }): string =>
+  toCategorySlug(post.category);

--- a/src/components/blog/index.ts
+++ b/src/components/blog/index.ts
@@ -7,6 +7,14 @@ export { default as BlogFooter } from './BlogFooter';
 export { default as BlogHeader } from './BlogHeader';
 export { default as BlogHero } from './BlogHero';
 export { default as BlogIndex } from './BlogIndex';
+export {
+  blogArticlePath,
+  blogCategoriesPath,
+  blogCategoryPath,
+  blogIndexPath,
+  postCategorySlug,
+  UNCATEGORIZED_SLUG,
+} from './blogUrls';
 export type { BlogCategoryRef } from './categories';
 export {
   findCategoryBySlug,
@@ -15,4 +23,5 @@ export {
   slugifyCategory,
 } from './categories';
 export { formatLongDate, formatShortDate } from './formatDate';
+export { default as HeaderCategoriesDropdown } from './HeaderCategoriesDropdown';
 export { default as SubscribeForm } from './SubscribeForm';

--- a/src/libs/email/notifyNewPost.ts
+++ b/src/libs/email/notifyNewPost.ts
@@ -1,3 +1,4 @@
+import { blogArticlePath } from '@/components/blog/blogUrls';
 import { EMAIL_CONFIG } from '@/libs/email/config';
 import { sendEmail } from '@/libs/email/sender';
 import { buildNewPostEmail } from '@/libs/email/templates/new-post';
@@ -18,7 +19,7 @@ const buildUnsubscribePageUrl = (token: string) =>
 const buildUnsubscribePostUrl = (token: string) =>
   `${EMAIL_CONFIG.baseUrl}/api/blog/unsubscribe?token=${encodeURIComponent(token)}`;
 
-const buildPostUrl = (slug: string) => `${EMAIL_CONFIG.baseUrl}/blog/${slug}`;
+const buildPostUrl = (post: BlogPost) => `${EMAIL_CONFIG.baseUrl}${blogArticlePath(post)}`;
 
 export type NotifyResult = {
   attempted: number;
@@ -60,7 +61,7 @@ export const notifyNewPost = async (post: BlogPost): Promise<NotifyResult> => {
       category: post.category,
       coverImage: post.coverImage,
       coverAlt: post.coverAlt,
-      postUrl: buildPostUrl(post.slug),
+      postUrl: buildPostUrl(post),
       unsubscribeUrl: unsubscribePageUrl,
     });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -210,6 +210,20 @@
     "notFound": "Category not found",
     "breadcrumbBlog": "Blog"
   },
+  "BlogCategories": {
+    "eyebrow": "Categories",
+    "title": "Everything we cover",
+    "subtitle": "Each category groups articles around one topic. Good if you only want to dig into one subject.",
+    "postCountOne": "{count} article",
+    "postCountOther": "{count} articles",
+    "exploreLink": "Explore category",
+    "metaTitle": "Blog Categories",
+    "metaDescription": "Complete list of categories on the Agility Creative blog — product, AI, design, management, and more."
+  },
+  "BlogHeader": {
+    "categoriesDropdownLabel": "Categories",
+    "categoriesDropdownAll": "View all categories"
+  },
   "BlogDetail": {
     "notFound": "Article not found",
     "breadcrumbBlog": "Blog",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -210,6 +210,20 @@
     "notFound": "Categoria não encontrada",
     "breadcrumbBlog": "Blog"
   },
+  "BlogCategories": {
+    "eyebrow": "Categorias",
+    "title": "Tudo o que cobrimos",
+    "subtitle": "Cada categoria reúne os artigos sobre um tema. Boa pra dar uma navegada quando você quer saber só de um assunto.",
+    "postCountOne": "{count} artigo",
+    "postCountOther": "{count} artigos",
+    "exploreLink": "Ver categoria",
+    "metaTitle": "Categorias do Blog",
+    "metaDescription": "Lista completa de categorias do blog da Agility Creative — produto, IA, design, gestão e mais."
+  },
+  "BlogHeader": {
+    "categoriesDropdownLabel": "Categorias",
+    "categoriesDropdownAll": "Ver todas as categorias"
+  },
   "BlogDetail": {
     "notFound": "Artigo não encontrado",
     "breadcrumbBlog": "Blog",

--- a/src/templates/BlogTemplate.tsx
+++ b/src/templates/BlogTemplate.tsx
@@ -4,9 +4,18 @@ import { AnimatePresence, motion } from 'motion/react';
 
 import BlogFooter from '@/components/blog/BlogFooter';
 import BlogHeader from '@/components/blog/BlogHeader';
+import type { BlogCategoryRef } from '@/components/blog/categories';
 import { usePathname } from '@/libs/i18nNavigation';
 
-const BlogTemplate = ({ children }: { children: React.ReactNode }) => {
+type BlogTemplateProps = {
+  children: React.ReactNode;
+  // Categories pre-fetched in the (server) layout — the header dropdown
+  // needs them but BlogTemplate is a client component, so we pass them down
+  // instead of refetching on the client.
+  categories?: BlogCategoryRef[];
+};
+
+const BlogTemplate = ({ children, categories = [] }: BlogTemplateProps) => {
   const pathname = usePathname();
 
   return (
@@ -21,7 +30,7 @@ const BlogTemplate = ({ children }: { children: React.ReactNode }) => {
           backgroundSize: '3px 3px',
         }}
       />
-      <BlogHeader />
+      <BlogHeader categories={categories} />
       <AnimatePresence mode="wait">
         <motion.main
           key={pathname}


### PR DESCRIPTION
## What changed

### 1. URL structure: articles now live at `/blog/{category}/{slug}`
Was: `/blog/{slug}` and `/blog/category/{slug}`. New:
- **`/blog/{category}/{slug}`** — canonical article URL.
- **`/blog/{category}`** — canonical category URL (the `/category/` segment dropped).
- **`/blog/categories`** — NEW categories hub (SEO landing page listing every category).
- **`/blog/{slug}` (single segment)** — smart resolver. If `slug` matches an old article, **308** → `/blog/{cat}/{slug}`. If it matches a category, render the category page. Else 404.
- **`/blog/category/{slug}`** — **308** → `/blog/{slug}`.
- **`/blog/{cat}/{slug}` with wrong category** — **308** → canonical.

Every old indexed URL gets a permanent redirect — SEO equity consolidates on the new shape. New `src/components/blog/blogUrls.ts` centralizes URL construction (`blogArticlePath`, `blogCategoryPath`, `blogCategoriesPath`, `blogIndexPath`). Every internal link, the sitemap, the RSS feed, and the email templates use these helpers now.

### 2. Breadcrumb on article pages now carries the category
`Blog / Categoria / Título do artigo` — the category crumb is clickable and goes to the category page.

### 3. Newsletter CTA at the bottom of every article
`SubscribeForm source="blog-article:{slug}"` inside the article column. Reads as a natural end-of-piece prompt.

### 4. Categories hub at `/blog/categories`
Grid of category cards with post counts. Mirrors the blog index visual language. `CollectionPage` + `ItemList` JSON-LD. Linked from the header dropdown's "Ver todas as categorias" footer.

### 5. Header navbar overhaul
- Removed the `Home` link.
- Added **Categorias** dropdown. Closes on Escape, click-outside, or item click. ARIA: `aria-haspopup="menu"`, `aria-controls`, `aria-expanded`, `role="menu"`/`role="menuitem"`.
- Categories fetched once in the (server) blog layout and forwarded down — no client-side refetch.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 141/141
- [x] Local smoke (13 paths verified): /blog 200; /blog/produto/mvp 200; /blog/mvp (legacy) 308; /blog/produto 200; /blog/category/produto 308; /blog/design/mvp (wrong cat) 308; /blog/categories 200; /blog/unknown 404; sitemap + RSS use new URLs; categories dropdown rendered; SubscribeForm at bottom of article; breadcrumb has category link.

## Notes for merger
- **Pre-push hook skipped** for this PR (`SKIP_PREPUSH=1`) because local disk is at 85% / 2.1 GB free and the full `next build` ran out of space. Lint + typecheck + tests passed locally before push. **Recommend Vercel CI does the build before merge** to validate.
- `src/app/[locale]/blog/[slug]/` renamed to `[category]/` to satisfy Next.js's consistent-param-names rule at the same depth.