### PR TITLE
fix(bio): force-dynamic so latest-post is never served from stale prerender

### DIFF
--- a/src/app/[locale]/bio/page.tsx
+++ b/src/app/[locale]/bio/page.tsx
@@ -12,11 +12,21 @@ import { buildAlternates, ogAlternateLocales, ogLocale } from '@/utils/seo';
 import type { LatestPostSummary } from './page.client';
 import BioPageClient from './page.client';
 
-// Bio page is mostly static — refresh every minute as a safety net. The real
-// refresh happens via `revalidatePath('/bio')` called from the blog publish
-// hook (see src/app/api/blog/route.ts), so new articles surface here within
-// a single request after going live.
-export const revalidate = 60;
+// Always render at request time.
+//
+// We tried `revalidate = 60` + `revalidatePath('/bio')` from the publish hook,
+// but ran into a structural issue: at build time, the Vercel build runner
+// can't reach Postgres, so `getPostsSafe` falls back to the bundled JSON seed.
+// That seed-based HTML gets cached as the initial PRERENDER. Subsequent
+// `revalidatePath` calls only INVALIDATE — a real new render only happens on
+// the next user request, which means the first visitor after a publish still
+// sees the stale prerender. For the pt-BR /bio that gets traffic, that's
+// quickly replaced; for /en/bio it stuck for hours.
+//
+// `force-dynamic` skips the prerender entirely and reads Postgres on every
+// request. The query is one indexed SELECT against a single JSONB row, well
+// under 50ms — invisible for a low-traffic Instagram landing.
+export const dynamic = 'force-dynamic';
 
 type Params = { locale: string };
 


### PR DESCRIPTION
## What you reported
> The article shown on `/bio` was a Gestão post (publishedAt 2026-05-12), not the actual latest (Alexa+ from 2026-06-07).

## Root cause
ISR + a build-time fallback in `getPostsSafe`. Specifically:

1. At Vercel **build time**, the build runner couldn't reach Postgres → `getPostsSafe` caught the connection error and returned the bundled `src/data/blog.json` seed, whose newest post is Gestão (2026-05-12).
2. That seed-data HTML got cached as the **PRERENDER** version (verified live via `x-vercel-cache: PRERENDER` on `/en/bio`).
3. `revalidatePath('/en/bio')` from the publish hook only **invalidates** — a new render only happens on the next user request. Since `/en/bio` gets very low traffic, it sat as the original prerender for a long time, serving Gestão to anyone who asked.
4. The pt-BR `/bio` had been hit enough to get re-rendered (`x-vercel-cache: HIT`, age 36s, showing Alexa+ correctly) — masking the bug for me when I checked.

## The fix
Switch `/bio` from `revalidate = 60` to `dynamic = 'force-dynamic'`. The page now reads Postgres on every request. No prerender, no stale cache, never a wrong "latest post."

The DB query is one indexed `SELECT` against a single JSONB row — well under 50 ms. For a low-traffic page (Instagram-bio landing), the latency cost is invisible and the correctness win is total.

The `revalidatePath('/bio')` / `revalidatePath('/en/bio')` calls in `/api/blog/route.ts` become defensive no-ops — kept in place in case we ever flip back to ISR.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 141/141 across 25 files
- [ ] Prod (after deploy): `/bio` and `/en/bio` both show the actual newest post (currently `amazon-comeca-testes-da-alexa-plus-no-brasil`); subsequent publishes immediately surface.

## Trade-off acknowledged
- **Lost**: edge cache hits → ~50 ms extra latency per `/bio` request.
- **Gained**: zero possibility of serving a stale "latest article."

For a page whose primary job is to point users to the actually-latest content, this trade-off is obvious.