### PR TITLE
feat(analytics): wire umami pageview tracking on prod only

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import '@/styles/global.css';
 
 import type { Metadata, Viewport } from 'next';
 import { Poppins, Sorts_Mill_Goudy } from 'next/font/google';
+import Script from 'next/script';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
 
@@ -104,6 +105,13 @@ export default async function RootLayout(props: {
         >
           {props.children}
         </NextIntlClientProvider>
+        {process.env.VERCEL_ENV === 'production' && (
+          <Script
+            src="https://cloud.umami.is/script.js"
+            data-website-id="fbef5db3-d9f6-407f-a106-7fb818d1ecf4"
+            strategy="afterInteractive"
+          />
+        )}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Drops the Umami snippet into `src/app/[locale]/layout.tsx` via `next/script` with `strategy="afterInteractive"` (idiomatic equivalent of the raw `defer`).
- Gated on `process.env.VERCEL_ENV === 'production'` so the `<Script>` tag is omitted from local dev and Vercel preview HTML — only the prod alias sends events.

Website ID: `fbef5db3-d9f6-407f-a106-7fb818d1ecf4` (cloud.umami.is).

## Test plan
- [ ] After merge + prod deploy: open https://www.agilitycreative.com/, devtools Network tab — `cloud.umami.is/script.js` loads once.
- [ ] Umami dashboard shows pageviews increasing on prod.
- [ ] A Vercel preview deploy of any subsequent PR has NO Umami script in its HTML (`view-source` should not contain `umami.is`).
- [ ] Local `npm run dev` HTML also has no Umami script.