### PR TITLE
feat(admin): subscribers page gated by basic auth

### DIFF
--- a/src/app/admin/subscribers/page.tsx
+++ b/src/app/admin/subscribers/page.tsx
@@ -1,0 +1,125 @@
+import { desc } from 'drizzle-orm';
+
+import { db } from '@/libs/DB';
+import { blogSubscribersSchema } from '@/models/Schema';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const STATUS_STYLE: Record<string, string> = {
+  confirmed: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+  pending: 'bg-amber-50 text-amber-700 ring-amber-200',
+  unsubscribed: 'bg-stone-100 text-stone-500 ring-stone-200',
+};
+
+const formatDate = (value: Date | null): string => {
+  if (!value) {
+    return '—';
+  }
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+    timeZone: 'America/Sao_Paulo',
+  }).format(value);
+};
+
+const AdminSubscribersPage = async () => {
+  const rows = await db
+    .select()
+    .from(blogSubscribersSchema)
+    .orderBy(desc(blogSubscribersSchema.createdAt));
+
+  const totals = rows.reduce(
+    (acc, r) => {
+      acc.total += 1;
+      acc[r.status as keyof typeof acc] = (acc[r.status as keyof typeof acc] ?? 0) + 1;
+      return acc;
+    },
+    { total: 0, confirmed: 0, pending: 0, unsubscribed: 0 },
+  );
+
+  return (
+    <main className="min-h-screen bg-stone-50 py-12">
+      <div className="mx-auto max-w-6xl px-6">
+        <header className="mb-10">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400">
+            Admin
+          </p>
+          <h1 className="mt-1 text-3xl font-semibold tracking-[-0.02em] text-stone-900">
+            Newsletter subscribers
+          </h1>
+        </header>
+
+        <section className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {([
+            { label: 'Total', value: totals.total, tone: 'text-stone-900' },
+            { label: 'Confirmados', value: totals.confirmed, tone: 'text-emerald-700' },
+            { label: 'Pendentes', value: totals.pending, tone: 'text-amber-700' },
+            { label: 'Cancelados', value: totals.unsubscribed, tone: 'text-stone-500' },
+          ]).map(stat => (
+            <div
+              key={stat.label}
+              className="rounded-2xl border border-stone-200/70 bg-white p-5"
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400">
+                {stat.label}
+              </p>
+              <p className={`mt-2 text-3xl font-semibold tracking-tight ${stat.tone}`}>
+                {stat.value}
+              </p>
+            </div>
+          ))}
+        </section>
+
+        <section className="overflow-hidden rounded-2xl border border-stone-200/70 bg-white">
+          <table className="w-full text-left text-[14px]">
+            <thead className="bg-stone-50 text-[11px] font-semibold uppercase tracking-[0.12em] text-stone-500">
+              <tr>
+                <th className="px-5 py-3">E-mail</th>
+                <th className="px-5 py-3">Status</th>
+                <th className="px-5 py-3">Source</th>
+                <th className="px-5 py-3">Locale</th>
+                <th className="px-5 py-3">Inscrição</th>
+                <th className="px-5 py-3">Confirmação</th>
+                <th className="px-5 py-3">Cancelamento</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-stone-100">
+              {rows.length === 0
+                ? (
+                    <tr>
+                      <td colSpan={7} className="px-5 py-12 text-center text-stone-400">
+                        Nenhum inscrito ainda.
+                      </td>
+                    </tr>
+                  )
+                : (
+                    rows.map(r => (
+                      <tr key={r.id} className="hover:bg-stone-50/60">
+                        <td className="px-5 py-3 font-medium text-stone-900">{r.email}</td>
+                        <td className="px-5 py-3">
+                          <span
+                            className={`inline-flex rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wider ring-1 ring-inset ${
+                              STATUS_STYLE[r.status] ?? 'bg-stone-100 text-stone-600 ring-stone-200'
+                            }`}
+                          >
+                            {r.status}
+                          </span>
+                        </td>
+                        <td className="px-5 py-3 text-stone-600">{r.source ?? '—'}</td>
+                        <td className="px-5 py-3 text-stone-600">{r.locale}</td>
+                        <td className="px-5 py-3 text-stone-600">{formatDate(r.createdAt)}</td>
+                        <td className="px-5 py-3 text-stone-600">{formatDate(r.confirmedAt)}</td>
+                        <td className="px-5 py-3 text-stone-600">{formatDate(r.unsubscribedAt)}</td>
+                      </tr>
+                    ))
+                  )}
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </main>
+  );
+};
+
+export default AdminSubscribersPage;

--- a/src/libs/Env.ts
+++ b/src/libs/Env.ts
@@ -7,6 +7,8 @@ export const Env = createEnv({
     CLERK_SECRET_KEY: z.string().min(1),
     DATABASE_URL: z.string().optional(),
     LOGTAIL_SOURCE_TOKEN: z.string().optional(),
+    ADMIN_USER: z.string().optional(),
+    ADMIN_PASSWORD: z.string().optional(),
   },
   client: {
     NEXT_PUBLIC_APP_URL: z.string().optional(),
@@ -21,6 +23,8 @@ export const Env = createEnv({
     CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
     DATABASE_URL: process.env.DATABASE_URL,
     LOGTAIL_SOURCE_TOKEN: process.env.LOGTAIL_SOURCE_TOKEN,
+    ADMIN_USER: process.env.ADMIN_USER,
+    ADMIN_PASSWORD: process.env.ADMIN_PASSWORD,
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
       process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -53,6 +53,38 @@ const localizedBlogRedirect = (request: NextRequest) => {
   return null;
 };
 
+// HTTP Basic Auth for /admin/*. Credentials are a shared user/password in
+// env (`ADMIN_USER` / `ADMIN_PASSWORD`) — these pages don't need per-user
+// identity, just a credential gate over operator-only views.
+const adminAuthGate = (request: NextRequest): NextResponse | null => {
+  if (!request.nextUrl.pathname.startsWith('/admin')) {
+    return null;
+  }
+  const user = process.env.ADMIN_USER;
+  const password = process.env.ADMIN_PASSWORD;
+  if (!user || !password) {
+    return new NextResponse('Admin disabled — set ADMIN_USER and ADMIN_PASSWORD.', {
+      status: 503,
+    });
+  }
+  const header = request.headers.get('authorization');
+  if (header?.startsWith('Basic ')) {
+    const decoded = atob(header.slice(6));
+    const sep = decoded.indexOf(':');
+    if (sep > 0) {
+      const u = decoded.slice(0, sep);
+      const p = decoded.slice(sep + 1);
+      if (u === user && p === password) {
+        return NextResponse.next();
+      }
+    }
+  }
+  return new NextResponse('Authentication required.', {
+    status: 401,
+    headers: { 'WWW-Authenticate': 'Basic realm="admin", charset="UTF-8"' },
+  });
+};
+
 // If the visitor previously chose a non-default locale (stored in the
 // NEXT_LOCALE cookie by the LocaleSwitcher), promote that choice to a real
 // redirect so the rest of the pipeline — and search engines — see the locale.
@@ -87,6 +119,13 @@ export default function middleware(
   // Don't let next-intl rewrite them to a localized page path.
   if (request.nextUrl.pathname.startsWith('/api/')) {
     return;
+  }
+
+  // Admin pages are gated by Basic Auth and not localized — handle them
+  // before the intl middleware gets a chance to rewrite the URL.
+  const adminGate = adminAuthGate(request);
+  if (adminGate) {
+    return adminGate;
   }
 
   // /en/blog* (and any other non-default locale prefix on /blog) canonicalizes


### PR DESCRIPTION
## Summary
- New page at `/admin/subscribers` showing every newsletter subscriber with status, source, locale, and timestamps. Pulls live from the `blog_subscribers` Postgres table.
- Top-of-page stat tiles for total / confirmed / pending / unsubscribed counts.
- Middleware gate (`src/middleware.ts`) intercepts `/admin/*` with HTTP Basic Auth using `ADMIN_USER` / `ADMIN_PASSWORD` env vars. No Clerk — this is a single-operator view, shared credential is enough. Without those env vars set, the route returns 503 so it can't be exposed by accident.
- Added `ADMIN_USER` / `ADMIN_PASSWORD` to `src/libs/Env.ts` (both optional).

## Before merge — set on Vercel
This will not work in production until the two env vars are configured on the Vercel project:
- `ADMIN_USER` — your chosen username
- `ADMIN_PASSWORD` — your chosen password (use something long)

Add via the Vercel dashboard or `vercel env add` for the Production (and Preview, if you want it usable there too) environment.

## Test plan
- [ ] After deploy + env config: hit `https://www.agilitycreative.com/admin/subscribers` → browser prompts for credentials.
- [ ] Cancel the prompt → page shows "Authentication required."
- [ ] Wrong credentials → 401.
- [ ] Right credentials → table renders with current subscribers, status pills color-coded.
- [ ] Before env config: same URL returns "Admin disabled — set ADMIN_USER and ADMIN_PASSWORD." (503).
- [ ] Other site routes (`/`, `/blog`, `/api/*`) still work unchanged.