### PR TITLE
feat(blog): redesign listing with horizontal cards, sticky sidebar, and load-more

### DIFF
--- a/src/app/[locale]/blog/[category]/page.tsx
+++ b/src/app/[locale]/blog/[category]/page.tsx
@@ -9,7 +9,7 @@ import {
   BlogHero,
   BlogIndex,
   findCategoryBySlug,
-  getOrderedCategories,
+  getPopularCategories,
   slugifyCategory,
 } from '@/components/blog';
 import { getPostsSafe } from '@/libs/blogStore';
@@ -123,9 +123,10 @@ const BlogCategoryOrLegacyArticlePage = async (props: { params: Promise<Params> 
     category: post.category,
     publishedAt: post.publishedAt,
     readingTimeMinutes: post.readingTimeMinutes,
+    author: post.author,
   }));
 
-  const categories = getOrderedCategories(posts.filter(isPublished));
+  const popularCategories = getPopularCategories(posts.filter(isPublished), 6);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -165,13 +166,14 @@ const BlogCategoryOrLegacyArticlePage = async (props: { params: Promise<Params> 
 
       <BlogIndex
         items={items}
-        categories={categories}
-        activeSlug={categorySegment}
+        popularCategories={popularCategories}
         locale={safeLocale}
-        allLabel={tBlog('allLabel')}
         readArticleLabel={tBlog('readArticle')}
         emptyLabel={tBlog('empty')}
-        moreLabel={tBlog('more')}
+        featuredLabel={tBlog('featured')}
+        latestLabel={tBlog('latest')}
+        popularCategoriesLabel={tBlog('popularCategories')}
+        loadMoreLabel={tBlog('loadMore')}
       />
 
       <script

--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
 import type { BlogCardItem } from '@/components/blog';
-import { BlogHero, BlogIndex, getOrderedCategories, SubscribeForm } from '@/components/blog';
+import { BlogHero, BlogIndex, getPopularCategories } from '@/components/blog';
 import { getPostsSafe } from '@/libs/blogStore';
 import { isPublished } from '@/types/blog';
 import { AppConfig } from '@/utils/AppConfig';
@@ -66,9 +66,10 @@ const BlogPage = async () => {
     category: post.category,
     publishedAt: post.publishedAt,
     readingTimeMinutes: post.readingTimeMinutes,
+    author: post.author,
   }));
 
-  const categories = getOrderedCategories(sortedPosts);
+  const popularCategories = getPopularCategories(sortedPosts, 6);
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -103,17 +104,15 @@ const BlogPage = async () => {
 
       <BlogIndex
         items={items}
-        categories={categories}
+        popularCategories={popularCategories}
         locale={safeLocale}
-        allLabel={t('allLabel')}
         readArticleLabel={t('readArticle')}
         emptyLabel={t('empty')}
-        moreLabel={t('more')}
+        featuredLabel={t('featured')}
+        latestLabel={t('latest')}
+        popularCategoriesLabel={t('popularCategories')}
+        loadMoreLabel={t('loadMore')}
       />
-
-      <div className="px-5 sm:px-8">
-        <SubscribeForm source="blog-index" />
-      </div>
 
       <script
         type="application/ld+json"

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 
 import { Link } from '@/libs/i18nNavigation';
+import type { BlogAuthor } from '@/types/blog';
 
 import { blogArticlePath } from './blogUrls';
 import { formatShortDate } from './formatDate';
@@ -16,6 +17,7 @@ export type BlogCardItem = {
   category?: string;
   publishedAt: string;
   readingTimeMinutes?: number;
+  author?: BlogAuthor;
 };
 
 type BlogCardProps = {

--- a/src/components/blog/BlogCardHorizontal.tsx
+++ b/src/components/blog/BlogCardHorizontal.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Image from 'next/image';
+
+import { Link } from '@/libs/i18nNavigation';
+
+import type { BlogCardItem } from './BlogCard';
+import { blogArticlePath } from './blogUrls';
+import { formatShortDate } from './formatDate';
+
+type BlogCardHorizontalProps = {
+  item: BlogCardItem;
+  locale: string;
+};
+
+const BlogCardHorizontal = ({ item, locale }: BlogCardHorizontalProps) => {
+  const dateLabel = formatShortDate(item.publishedAt, locale);
+
+  return (
+    <Link
+      href={blogArticlePath(item)}
+      className="group flex items-start gap-5 py-8 first:pt-0 sm:gap-7 [&+&]:border-t [&+&]:border-stone-200/70"
+    >
+      {item.coverImage
+        ? (
+            <div className="relative size-[110px] shrink-0 overflow-hidden rounded-2xl bg-stone-100 ring-1 ring-inset ring-black/[0.04] sm:size-[140px] md:size-[160px]">
+              <Image
+                src={item.coverImage}
+                alt={item.coverAlt ?? item.title}
+                fill
+                sizes="(max-width: 640px) 110px, (max-width: 768px) 140px, 160px"
+                className="object-cover transition-transform duration-[900ms] ease-out group-hover:scale-[1.06]"
+              />
+            </div>
+          )
+        : (
+            <div className="size-[110px] shrink-0 rounded-2xl bg-gradient-to-br from-stone-100 to-stone-200 sm:size-[140px] md:size-[160px]" />
+          )}
+
+      <div className="flex flex-1 flex-col gap-3 pt-1">
+        <h3 className="text-[18px] font-semibold leading-snug tracking-[-0.01em] text-stone-900 transition-colors duration-300 group-hover:text-primary sm:text-[20px] md:text-[22px]">
+          {item.title}
+        </h3>
+
+        <div className="flex flex-wrap items-center gap-2 text-[13px] text-stone-500">
+          {item.category && (
+            <>
+              <span className="font-medium text-stone-700">{item.category}</span>
+              <span aria-hidden className="text-stone-300">/</span>
+            </>
+          )}
+          <span>{dateLabel}</span>
+        </div>
+
+        <p className="line-clamp-2 text-[14px] leading-relaxed text-stone-500">
+          {item.excerpt}
+        </p>
+      </div>
+    </Link>
+  );
+};
+
+export default BlogCardHorizontal;

--- a/src/components/blog/BlogFeaturedCard.tsx
+++ b/src/components/blog/BlogFeaturedCard.tsx
@@ -12,68 +12,62 @@ type BlogFeaturedCardProps = {
   item: BlogCardItem;
   locale: string;
   readArticleLabel: string;
+  eyebrowLabel?: string;
 };
 
-const BlogFeaturedCard = ({ item, locale, readArticleLabel }: BlogFeaturedCardProps) => {
+const BlogFeaturedCard = ({ item, locale, readArticleLabel, eyebrowLabel }: BlogFeaturedCardProps) => {
   const dateLabel = formatShortDate(item.publishedAt, locale);
 
   return (
-    <Link
-      href={blogArticlePath(item)}
-      className="group relative grid grid-cols-1 overflow-hidden rounded-3xl border border-stone-200/70 bg-white shadow-[0_1px_2px_rgba(0,0,0,0.02)] transition-all duration-500 hover:-translate-y-0.5 hover:border-stone-300/70 hover:shadow-[0_24px_60px_-20px_rgba(0,0,0,0.18),0_8px_20px_-12px_rgba(0,0,0,0.08)] lg:grid-cols-[1.55fr_1fr]"
-    >
-      {item.coverImage
-        ? (
-            <div className="relative aspect-[16/10] overflow-hidden bg-gradient-to-br from-stone-100 to-stone-50 lg:aspect-auto">
-              <Image
-                src={item.coverImage}
-                alt={item.coverAlt ?? item.title}
-                fill
-                sizes="(max-width: 1024px) 100vw, 60vw"
-                className="object-cover transition-transform duration-[1200ms] ease-out group-hover:scale-[1.04]"
-                priority
-              />
-              {/* Subtle inner vignette — gives the image more depth without darkening it. */}
-              <div
-                aria-hidden
-                className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-black/[0.04]"
-              />
-            </div>
-          )
-        : (
-            <div className="aspect-[16/10] bg-gradient-to-br from-stone-100 to-stone-50 lg:aspect-auto" />
-          )}
-
-      <div className="flex flex-col justify-center gap-6 p-8 md:p-12 lg:p-14">
-        <div className="flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400">
-          <span>{dateLabel}</span>
-          {item.category && (
-            <>
-              <span aria-hidden className="size-1 rounded-full bg-stone-300" />
-              <span className="text-primary">{item.category}</span>
-            </>
-          )}
-        </div>
-
-        <h2 className="text-[1.875rem] font-semibold leading-[1.1] tracking-[-0.02em] text-stone-900 transition-colors duration-300 md:text-[2.25rem] lg:text-[2.5rem]">
-          {item.title}
-        </h2>
-
-        <p className="line-clamp-3 text-[15px] leading-relaxed text-stone-500">
-          {item.excerpt}
+    <section aria-label={readArticleLabel}>
+      {eyebrowLabel && (
+        <p className="mb-6 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400">
+          {eyebrowLabel}
         </p>
+      )}
 
-        <span className="mt-2 inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-900">
-          {readArticleLabel}
-          <span className="inline-flex size-8 items-center justify-center rounded-full bg-stone-900 text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-transform duration-300 group-hover:translate-x-1">
-            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <line x1="5" y1="12" x2="19" y2="12" />
-              <polyline points="12 5 19 12 12 19" />
-            </svg>
-          </span>
-        </span>
-      </div>
-    </Link>
+      <Link
+        href={blogArticlePath(item)}
+        className="group grid grid-cols-1 items-center gap-8 md:gap-12 lg:grid-cols-[1fr_1.1fr]"
+      >
+        {item.coverImage
+          ? (
+              <div className="relative aspect-[16/11] overflow-hidden rounded-2xl bg-gradient-to-br from-stone-100 to-stone-50 ring-1 ring-inset ring-black/[0.04]">
+                <Image
+                  src={item.coverImage}
+                  alt={item.coverAlt ?? item.title}
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 50vw"
+                  className="object-cover transition-transform duration-[1200ms] ease-out group-hover:scale-[1.04]"
+                  priority
+                />
+              </div>
+            )
+          : (
+              <div className="aspect-[16/11] rounded-2xl bg-gradient-to-br from-stone-100 to-stone-50" />
+            )}
+
+        <div className="flex flex-col gap-5">
+          <h2 className="text-[1.75rem] font-semibold leading-[1.1] tracking-[-0.02em] text-stone-900 transition-colors duration-300 group-hover:text-primary md:text-[2.125rem] lg:text-[2.5rem]">
+            {item.title}
+          </h2>
+
+          <div className="flex flex-wrap items-center gap-2 text-[13px] text-stone-500">
+            {item.category && (
+              <>
+                <span className="font-medium text-stone-700">{item.category}</span>
+                <span aria-hidden className="text-stone-300">/</span>
+              </>
+            )}
+            <span>{dateLabel}</span>
+          </div>
+
+          <p className="line-clamp-3 text-[15px] leading-relaxed text-stone-500">
+            {item.excerpt}
+          </p>
+        </div>
+      </Link>
+    </section>
   );
 };
 

--- a/src/components/blog/BlogFooter.tsx
+++ b/src/components/blog/BlogFooter.tsx
@@ -9,7 +9,7 @@ const BlogFooter = () => {
   const tBlog = useTranslations('BlogPage');
 
   return (
-    <footer className="relative border-t border-stone-200/70 bg-stone-50">
+    <footer className="relative border-t border-stone-200/70 bg-white">
       <div className="mx-auto max-w-6xl px-5 py-16 sm:px-8 md:py-20">
         <div className="grid grid-cols-1 gap-12 md:grid-cols-[1.4fr_1fr_1fr]">
           <div className="max-w-sm">

--- a/src/components/blog/BlogHeader.tsx
+++ b/src/components/blog/BlogHeader.tsx
@@ -37,8 +37,8 @@ const BlogHeader = ({ categories = [] }: BlogHeaderProps) => {
     <motion.header
       className={`sticky top-0 z-50 transition-[background-color,border-color,backdrop-filter] duration-300 ${
         scrolled
-          ? 'border-b border-stone-200/70 bg-stone-50/80 backdrop-blur-xl'
-          : 'border-b border-transparent bg-stone-50'
+          ? 'border-b border-stone-200/70 bg-white/80 backdrop-blur-xl'
+          : 'border-b border-transparent bg-white'
       }`}
       initial={{ y: -80, opacity: 0 }}
       animate={{ y: hidden ? -80 : 0, opacity: 1 }}

--- a/src/components/blog/BlogHero.tsx
+++ b/src/components/blog/BlogHero.tsx
@@ -18,7 +18,7 @@ type BlogHeroProps = {
 const SIZE_TO_TITLE = {
   sm: 'text-3xl md:text-4xl',
   md: 'text-4xl md:text-5xl lg:text-[3.5rem]',
-  lg: 'text-[2.5rem] leading-[1.05] md:text-6xl lg:text-[4.25rem]',
+  lg: 'text-[2rem] leading-[1.05] md:text-5xl lg:text-[3.25rem]',
 } as const;
 
 const BlogHero = ({
@@ -39,7 +39,7 @@ const BlogHero = ({
         aria-hidden
         className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-stone-300/60 to-transparent"
       />
-      <div className={`mx-auto max-w-6xl px-5 pb-14 pt-16 sm:px-8 md:pb-20 md:pt-28 ${isCenter ? 'text-center' : 'text-left'}`}>
+      <div className={`mx-auto max-w-6xl px-5 pb-10 pt-12 sm:px-8 md:pb-14 md:pt-20 ${isCenter ? 'text-center' : 'text-left'}`}>
         {breadcrumbs && breadcrumbs.length > 0 && (
           <nav
             aria-label="Breadcrumb"
@@ -62,7 +62,7 @@ const BlogHero = ({
           </nav>
         )}
 
-        <div className={isCenter ? 'mx-auto max-w-3xl' : 'max-w-4xl'}>
+        <div className={isCenter ? 'mx-auto max-w-3xl' : ''}>
           {eyebrow && (
             <div className={`mb-6 flex items-center gap-3 ${isCenter ? 'justify-center' : ''}`}>
               <span aria-hidden className="h-px w-8 bg-primary" />
@@ -77,7 +77,7 @@ const BlogHero = ({
           </h1>
 
           {subtitle && (
-            <p className={`mt-6 text-lg leading-relaxed text-stone-500 md:mt-7 md:text-xl ${isCenter ? 'mx-auto max-w-2xl' : 'max-w-2xl'}`}>
+            <p className={`mt-5 text-[15px] leading-relaxed text-stone-500 md:mt-6 md:text-base ${isCenter ? 'mx-auto max-w-2xl' : 'max-w-3xl'}`}>
               {subtitle}
             </p>
           )}

--- a/src/components/blog/BlogIndex.tsx
+++ b/src/components/blog/BlogIndex.tsx
@@ -1,72 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+
 import type { BlogCardItem } from './BlogCard';
-import BlogCard from './BlogCard';
-import BlogCategoryTabs, { ALL_SLUG } from './BlogCategoryTabs';
+import BlogCardHorizontal from './BlogCardHorizontal';
 import BlogFeaturedCard from './BlogFeaturedCard';
-import type { BlogCategoryRef } from './categories';
+import BlogSidebar from './BlogSidebar';
+import type { BlogCategoryWithCount } from './categories';
+
+const PAGE_SIZE = 12;
 
 type BlogIndexProps = {
   items: BlogCardItem[];
-  categories: BlogCategoryRef[];
-  activeSlug?: string;
+  popularCategories: BlogCategoryWithCount[];
   locale: string;
-  allLabel: string;
   readArticleLabel: string;
   emptyLabel: string;
-  moreLabel?: string;
+  featuredLabel: string;
+  latestLabel: string;
+  popularCategoriesLabel: string;
+  loadMoreLabel: string;
 };
 
 const BlogIndex = ({
   items,
-  categories,
-  activeSlug = ALL_SLUG,
+  popularCategories,
   locale,
-  allLabel,
   readArticleLabel,
   emptyLabel,
-  moreLabel,
+  featuredLabel,
+  latestLabel,
+  popularCategoriesLabel,
+  loadMoreLabel,
 }: BlogIndexProps) => {
   const [featured, ...rest] = items;
+  const [page, setPage] = useState(1);
+
+  const visibleItems = rest.slice(0, page * PAGE_SIZE);
+  const hasMore = rest.length > visibleItems.length;
 
   return (
     <section className="mx-auto max-w-6xl px-5 pb-28 pt-2 sm:px-8 md:pb-36 md:pt-4">
-      <BlogCategoryTabs
-        categories={categories}
-        activeSlug={activeSlug}
-        allLabel={allLabel}
-      />
-
       {!featured && (
-        <p className="mt-16 rounded-2xl border border-dashed border-stone-200 bg-white/40 px-6 py-20 text-center text-sm text-stone-500">
+        <p className="mt-8 rounded-2xl border border-dashed border-stone-200 bg-white/40 px-6 py-20 text-center text-sm text-stone-500">
           {emptyLabel}
         </p>
       )}
 
       {featured && (
-        <div className="mt-10 md:mt-12">
-          <BlogFeaturedCard
-            item={featured}
-            locale={locale}
-            readArticleLabel={readArticleLabel}
-          />
-        </div>
+        <BlogFeaturedCard
+          item={featured}
+          locale={locale}
+          readArticleLabel={readArticleLabel}
+          eyebrowLabel={featuredLabel}
+        />
       )}
 
       {rest.length > 0 && (
-        <div className="mt-16 md:mt-20">
-          {moreLabel && (
-            <div className="mb-8 flex items-center gap-4">
-              <span aria-hidden className="h-px w-10 bg-stone-300" />
-              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
-                {moreLabel}
+        <>
+          <hr aria-hidden className="my-14 border-stone-200/70 md:my-16" />
+          <div className="grid grid-cols-1 gap-12 lg:grid-cols-[2fr_1fr] lg:gap-16">
+            <div>
+              <p className="mb-6 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400">
+                {latestLabel}
               </p>
+              <div className="flex flex-col">
+                {visibleItems.map(item => (
+                  <BlogCardHorizontal key={item.slug} item={item} locale={locale} />
+                ))}
+              </div>
+
+              {hasMore && (
+                <div className="mt-10 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => setPage(p => p + 1)}
+                    className="inline-flex h-11 items-center justify-center gap-2 rounded-full border border-stone-200/70 bg-white px-6 text-[13px] font-medium tracking-tight text-stone-700 shadow-[0_1px_2px_rgba(0,0,0,0.02)] transition-all hover:-translate-y-0.5 hover:border-stone-300 hover:text-stone-900 hover:shadow-[0_8px_20px_-12px_rgba(0,0,0,0.12)]"
+                  >
+                    {loadMoreLabel}
+                    <span aria-hidden className="text-stone-400">↓</span>
+                  </button>
+                </div>
+              )}
             </div>
-          )}
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {rest.map(item => (
-              <BlogCard key={item.slug} item={item} locale={locale} />
-            ))}
+
+            <BlogSidebar
+              popularCategories={popularCategories}
+              popularCategoriesLabel={popularCategoriesLabel}
+            />
           </div>
-        </div>
+        </>
       )}
     </section>
   );

--- a/src/components/blog/BlogSidebar.tsx
+++ b/src/components/blog/BlogSidebar.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Link } from '@/libs/i18nNavigation';
+
+import { blogCategoryPath } from './blogUrls';
+import type { BlogCategoryWithCount } from './categories';
+import SubscribeForm from './SubscribeForm';
+
+type BlogSidebarProps = {
+  popularCategories: BlogCategoryWithCount[];
+  popularCategoriesLabel: string;
+};
+
+const BlogSidebar = ({ popularCategories, popularCategoriesLabel }: BlogSidebarProps) => {
+  return (
+    <aside className="lg:sticky lg:top-[88px] lg:self-start">
+      <div className="rounded-2xl border border-stone-200/70 bg-stone-50/60 p-6">
+        <SubscribeForm source="blog-sidebar" variant="sidebar" />
+      </div>
+
+      {popularCategories.length > 0 && (
+        <div className="mt-10">
+          <p className="mb-5 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400">
+            {popularCategoriesLabel}
+          </p>
+          <ul className="flex flex-col">
+            {popularCategories.map(cat => (
+              <li key={cat.slug}>
+                <Link
+                  href={blogCategoryPath(cat)}
+                  className="group flex items-center gap-3 py-2.5"
+                >
+                  <span className="flex-1 truncate text-[14px] font-medium text-stone-700 transition-colors group-hover:text-primary">
+                    {cat.label}
+                  </span>
+                  <span className="text-[11px] tabular-nums text-stone-400">
+                    {cat.count}
+                  </span>
+                  <svg
+                    aria-hidden
+                    viewBox="0 0 24 24"
+                    width="14"
+                    height="14"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="text-stone-300 transition-all duration-300 group-hover:translate-x-0.5 group-hover:text-stone-500"
+                  >
+                    <polyline points="9 18 15 12 9 6" />
+                  </svg>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default BlogSidebar;

--- a/src/components/blog/SubscribeForm.tsx
+++ b/src/components/blog/SubscribeForm.tsx
@@ -10,6 +10,7 @@ type SubmitState
 
 type SubscribeFormProps = {
   source?: string;
+  variant?: 'full' | 'sidebar';
 };
 
 // Server should answer the subscribe POST well under a second. If we don't
@@ -73,7 +74,8 @@ const COPY = {
   privacy: 'Você pode cancelar a inscrição a qualquer momento.',
 };
 
-const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
+const SubscribeForm = ({ source = 'blog-index', variant = 'full' }: SubscribeFormProps) => {
+  const isSidebar = variant === 'sidebar';
   const [email, setEmail] = useState('');
   const [state, setState] = useState<SubmitState>({ kind: 'idle' });
   const [focused, setFocused] = useState(false);
@@ -163,23 +165,44 @@ const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
 
   if (state.kind === 'success') {
     return (
-      <section className="mx-auto my-20 max-w-3xl rounded-3xl border border-stone-200/70 bg-white p-10 text-center shadow-[0_1px_2px_rgba(0,0,0,0.02)] sm:p-14">
-        <p className="mb-4 inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary">
+      <section
+        className={
+          isSidebar
+            ? ''
+            : 'mx-auto my-20 max-w-3xl rounded-3xl border border-stone-200/70 bg-white p-10 text-center shadow-[0_1px_2px_rgba(0,0,0,0.02)] sm:p-14'
+        }
+      >
+        <p className={`${isSidebar ? 'mb-3' : 'mb-4'} inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary`}>
           <span aria-hidden className="h-px w-8 bg-primary" />
           Verifique seu e-mail
         </p>
-        <h2 className="text-2xl font-semibold leading-tight tracking-[-0.02em] text-stone-900 md:text-3xl">
+        <h2 className={
+          isSidebar
+            ? 'text-[17px] font-semibold leading-tight tracking-[-0.01em] text-stone-900'
+            : 'text-2xl font-semibold leading-tight tracking-[-0.02em] text-stone-900 md:text-3xl'
+        }
+        >
           {COPY.successTitle}
         </h2>
-        <p className="mx-auto mt-4 max-w-lg text-[15px] leading-relaxed text-stone-600">
+        <p className={
+          isSidebar
+            ? 'mt-3 text-[13px] leading-relaxed text-stone-600'
+            : 'mx-auto mt-4 max-w-lg text-[15px] leading-relaxed text-stone-600'
+        }
+        >
           {COPY.successBodyStrong}
           {' '}
-          <span className="rounded-md bg-stone-900 px-2 py-0.5 text-[13px] font-medium text-stone-50">
+          <span className="rounded-md bg-stone-900 px-2 py-0.5 text-[12px] font-medium text-stone-50">
             {COPY.successBodyButton}
           </span>
           {COPY.successBodyTail}
         </p>
-        <p className="mx-auto mt-5 max-w-md text-[12px] leading-relaxed text-stone-400">
+        <p className={
+          isSidebar
+            ? 'mt-3 text-[11.5px] leading-relaxed text-stone-400'
+            : 'mx-auto mt-5 max-w-md text-[12px] leading-relaxed text-stone-400'
+        }
+        >
           {COPY.successFootnote}
         </p>
       </section>
@@ -187,21 +210,40 @@ const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
   }
 
   return (
-    <section className="mx-auto my-20 max-w-3xl rounded-3xl border border-stone-200/70 bg-white p-10 shadow-[0_1px_2px_rgba(0,0,0,0.02)] sm:p-14">
-      <div className="text-center">
-        <p className="mb-4 inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary">
-          <span aria-hidden className="h-px w-8 bg-primary" />
-          {COPY.eyebrow}
-        </p>
-        <h2 className="text-2xl font-semibold leading-tight tracking-[-0.02em] text-stone-900 md:text-[1.875rem]">
-          {COPY.title}
-        </h2>
-        <p className="mx-auto mt-4 max-w-md text-[15px] leading-relaxed text-stone-500">
-          {COPY.subtitle}
-        </p>
-      </div>
+    <section
+      className={
+        isSidebar
+          ? ''
+          : 'mx-auto my-20 max-w-3xl rounded-3xl border border-stone-200/70 bg-white p-10 shadow-[0_1px_2px_rgba(0,0,0,0.02)] sm:p-14'
+      }
+    >
+      {isSidebar
+        ? (
+            <div>
+              <h2 className="text-[17px] font-semibold leading-snug tracking-[-0.01em] text-stone-900">
+                {COPY.title}
+              </h2>
+              <p className="mt-2 text-[13px] leading-relaxed text-stone-500">
+                {COPY.subtitle}
+              </p>
+            </div>
+          )
+        : (
+            <div className="text-center">
+              <p className="mb-4 inline-flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-primary">
+                <span aria-hidden className="h-px w-8 bg-primary" />
+                {COPY.eyebrow}
+              </p>
+              <h2 className="text-2xl font-semibold leading-tight tracking-[-0.02em] text-stone-900 md:text-[1.875rem]">
+                {COPY.title}
+              </h2>
+              <p className="mx-auto mt-4 max-w-md text-[15px] leading-relaxed text-stone-500">
+                {COPY.subtitle}
+              </p>
+            </div>
+          )}
 
-      <form onSubmit={handleSubmit} className="mt-8 flex flex-col gap-3 sm:flex-row" noValidate>
+      <form onSubmit={handleSubmit} className={`${isSidebar ? 'mt-4 flex flex-col gap-2' : 'mt-8 flex flex-col gap-3 sm:flex-row'}`} noValidate>
         <label className="relative flex-1">
           <span className="sr-only">{COPY.emailLabel}</span>
           <input
@@ -231,7 +273,9 @@ const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
               showSuggestions && highlight >= 0 ? `${listboxId}-${highlight}` : undefined
             }
             aria-invalid={state.kind === 'error'}
-            className="h-12 w-full rounded-full border border-stone-200/70 bg-stone-50 px-5 text-[15px] text-stone-900 outline-none transition-colors placeholder:text-stone-400 hover:border-stone-300 focus:border-stone-400 focus:bg-white focus:ring-4 focus:ring-stone-900/5"
+            className={`w-full rounded-full border border-stone-200/70 bg-stone-100 text-stone-900 outline-none transition-colors placeholder:text-stone-400 hover:border-stone-300 focus:border-stone-400 focus:bg-white focus:ring-4 focus:ring-stone-900/5 ${
+              isSidebar ? 'h-11 px-4 text-[14px]' : 'h-12 px-5 text-[15px]'
+            }`}
           />
           {showSuggestions && (
             <ul
@@ -265,7 +309,9 @@ const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
         <button
           type="submit"
           disabled={state.kind === 'submitting'}
-          className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-stone-900 px-6 text-[14px] font-medium tracking-tight text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all hover:bg-stone-800 hover:shadow-[0_4px_12px_rgba(0,0,0,0.12),inset_0_1px_0_rgba(255,255,255,0.08)] disabled:cursor-not-allowed disabled:opacity-60"
+          className={`inline-flex items-center justify-center gap-2 rounded-full bg-stone-900 font-medium tracking-tight text-stone-50 shadow-[0_1px_2px_rgba(0,0,0,0.08),inset_0_1px_0_rgba(255,255,255,0.08)] transition-all hover:bg-stone-800 hover:shadow-[0_4px_12px_rgba(0,0,0,0.12),inset_0_1px_0_rgba(255,255,255,0.08)] disabled:cursor-not-allowed disabled:opacity-60 ${
+            isSidebar ? 'h-11 px-5 text-[13px]' : 'h-12 px-6 text-[14px]'
+          }`}
         >
           {state.kind === 'submitting' ? COPY.ctaLoading : COPY.cta}
           {state.kind !== 'submitting' && (
@@ -274,7 +320,7 @@ const SubscribeForm = ({ source = 'blog-index' }: SubscribeFormProps) => {
         </button>
       </form>
 
-      <div className="mt-4 flex min-h-[20px] items-center justify-center text-[12px]">
+      <div className={`mt-3 flex min-h-[20px] items-center text-[12px] ${isSidebar ? 'justify-start' : 'justify-center'}`}>
         {state.kind === 'error'
           ? (
               <p className="text-rose-600" role="alert">

--- a/src/components/blog/categories.ts
+++ b/src/components/blog/categories.ts
@@ -42,3 +42,27 @@ export const findCategoryBySlug = (
 
 export const getAllCategorySlugs = (posts: Pick<BlogPost, 'category'>[]): string[] =>
   getOrderedCategories(posts).map(category => category.slug);
+
+export type BlogCategoryWithCount = BlogCategoryRef & { count: number };
+
+export const getPopularCategories = (
+  posts: Pick<BlogPost, 'category'>[],
+  limit: number,
+): BlogCategoryWithCount[] => {
+  const counts = new Map<string, BlogCategoryWithCount>();
+  for (const post of posts) {
+    if (!post.category) {
+      continue;
+    }
+    const slug = slugifyCategory(post.category);
+    const existing = counts.get(slug);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      counts.set(slug, { slug, label: post.category, count: 1 });
+    }
+  }
+  return [...counts.values()]
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+    .slice(0, limit);
+};

--- a/src/components/blog/index.ts
+++ b/src/components/blog/index.ts
@@ -1,12 +1,13 @@
 export { default as BlogArticleBody } from './BlogArticleBody';
 export type { BlogCardItem } from './BlogCard';
 export { default as BlogCard } from './BlogCard';
-export { ALL_SLUG, default as BlogCategoryTabs } from './BlogCategoryTabs';
+export { default as BlogCardHorizontal } from './BlogCardHorizontal';
 export { default as BlogFeaturedCard } from './BlogFeaturedCard';
 export { default as BlogFooter } from './BlogFooter';
 export { default as BlogHeader } from './BlogHeader';
 export { default as BlogHero } from './BlogHero';
 export { default as BlogIndex } from './BlogIndex';
+export { default as BlogSidebar } from './BlogSidebar';
 export {
   blogArticlePath,
   blogCategoriesPath,
@@ -15,11 +16,12 @@ export {
   postCategorySlug,
   UNCATEGORIZED_SLUG,
 } from './blogUrls';
-export type { BlogCategoryRef } from './categories';
+export type { BlogCategoryRef, BlogCategoryWithCount } from './categories';
 export {
   findCategoryBySlug,
   getAllCategorySlugs,
   getOrderedCategories,
+  getPopularCategories,
   slugifyCategory,
 } from './categories';
 export { formatLongDate, formatShortDate } from './formatDate';

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -195,11 +195,13 @@
     "badge": "Blog da Agility",
     "titlePrefix": "Tecnologia, IA e ideias",
     "titleHighlight": "que importam",
-    "subtitle": "Novidades de inteligência artificial, tutoriais de produto, curiosidades de tecnologia e bastidores da Agility — em uma linguagem que serve tanto para quem programa quanto para quem só quer entender o que está acontecendo.",
+    "subtitle": "IA, tecnologia e bastidores do time — em linguagem que serve pra quem programa e pra quem só quer entender.",
     "readingTimeSuffix": "min de leitura",
-    "allLabel": "Todos",
     "readArticle": "Leia o artigo",
-    "more": "Mais artigos",
+    "featured": "Artigo em destaque",
+    "latest": "Últimos artigos",
+    "popularCategories": "Categorias populares",
+    "loadMore": "Carregar mais",
     "empty": "Ainda não temos posts nessa categoria — volte em breve."
   },
   "BlogCategory": {

--- a/src/templates/BlogTemplate.tsx
+++ b/src/templates/BlogTemplate.tsx
@@ -19,17 +19,7 @@ const BlogTemplate = ({ children, categories = [] }: BlogTemplateProps) => {
   const pathname = usePathname();
 
   return (
-    <div className="flex min-h-screen flex-col bg-stone-50 font-poppins text-stone-900 antialiased selection:bg-stone-900 selection:text-stone-50">
-      {/* Subtle grain overlay — barely perceptible, kills the flatness of pure off-white. */}
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 z-0 opacity-[0.025] mix-blend-multiply"
-        style={{
-          backgroundImage:
-            'radial-gradient(circle at 1px 1px, rgba(0,0,0,0.7) 1px, transparent 0)',
-          backgroundSize: '3px 3px',
-        }}
-      />
+    <div className="flex min-h-screen flex-col bg-white font-poppins text-stone-900 antialiased selection:bg-stone-900 selection:text-stone-50">
       <BlogHeader categories={categories} />
       <AnimatePresence mode="wait">
         <motion.main


### PR DESCRIPTION
## Summary
- **Hero tightened** so the featured article now enters the first fold — title sizes down from `4.25rem → 3.25rem`, subtitle from `text-xl → text-base`, vertical padding reduced, and the pt-BR subtitle copy shortened to one line.
- **Removed the in-page category navbar** — it was redundant with `HeaderCategoriesDropdown` in `BlogHeader`. `BlogCategoryTabs.tsx` is left orphaned for now (not deleted) per project deletion policy.
- **Page background switched to pure white**, grain overlay removed in `BlogTemplate`; `BlogHeader` + `BlogFooter` matched; `SubscribeForm` input bg bumped to `stone-100` so it still reads as an input on white.
- **Featured card un-carded** — no border/bg/shadow, just an image-left / text-right grid sitting on the page. Meta row is plain `{category} / {date}` (no author avatar, no bottom category pill).
- **New `BlogCardHorizontal` component** for the "Últimos artigos" list — rounded-rectangle thumbnail on the left, title + `{category} / {date}` + excerpt on the right. Hairline divider between rows, no card chrome.
- **New 2/3 + 1/3 grid** with a sticky sidebar (`BlogSidebar`) — sticky boundary is the grid cell itself, so the sidebar naturally releases when the article column ends (no IntersectionObserver needed).
- **Compact newsletter widget** in the sidebar via new `variant="sidebar"` on `SubscribeForm` — no card chrome, inline form, smaller type.
- **Popular categories widget** in the sidebar — clean text rows with a count + chevron-right icon, sorted by post count via new `getPopularCategories(posts, limit)` helper in `categories.ts`.
- **Load-more pagination** — 12 articles per page; button hides when exhausted (`Carregar mais` pill).
- Applied to both `/blog` and `/blog/[category]` since they share `BlogIndex`.

## Notes
- `BlogCategoryTabs.tsx` is orphaned after this change but not deleted (deletion policy is strict on this repo).
- The avatar-cluster + "1.4k+" social-proof badge from the reference image is intentionally not shipped — we don't have real subscriber counts yet. Easy to drop in later.

## Test plan
- [ ] `/blog` on a 1366×768 viewport: hero + at least the top of the featured card image are above the fold.
- [ ] No category navbar between hero and featured card.
- [ ] Page background is pure white, no grain, no card around the article list.
- [ ] Featured card: image left, eyebrow + title + `{category} / {date}` + excerpt on the right. No author avatar, no bottom pill.
- [ ] "Últimos artigos" rows: rounded thumb left, title + meta + excerpt right, hairline between rows.
- [ ] Sidebar visible on `lg+`, stacks below the list on smaller breakpoints.
- [ ] Scroll past the article list — sidebar sticks until the list ends, then scrolls naturally away (no overlap with footer).
- [ ] If there are > 12 secondary articles, "Carregar mais" appears; click it → next 12 render; button disappears when exhausted.
- [ ] Visit `/blog/inteligencia-artificial` (or any other live category) → same layout applies, no broken imports.
- [ ] Popular categories rows in the sidebar link through to their category pages.
- [ ] Newsletter sidebar form submits successfully (`source=blog-sidebar` in the request body).