### PR TITLE
feat(admin): sign-in page, dashboard shell, cookie session

### DIFF
--- a/src/app/admin/LogoutButton.tsx
+++ b/src/app/admin/LogoutButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+const LogoutButton = () => {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  const onClick = async () => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await fetch('/api/admin/logout', { method: 'POST' });
+      router.replace('/admin/login');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      className="inline-flex h-9 items-center justify-center rounded-full border border-stone-200/70 bg-white px-4 text-[12px] font-medium text-stone-600 transition-colors hover:bg-stone-50 hover:text-stone-900 disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {busy ? 'Saindo…' : 'Sair'}
+    </button>
+  );
+};
+
+export default LogoutButton;

--- a/src/app/admin/_components/DashboardShell.tsx
+++ b/src/app/admin/_components/DashboardShell.tsx
@@ -1,0 +1,33 @@
+import LogoutButton from '@/app/admin/LogoutButton';
+
+import Sidebar from './Sidebar';
+
+type DashboardShellProps = {
+  title: string;
+  eyebrow?: string;
+  children: React.ReactNode;
+};
+
+const DashboardShell = ({ title, eyebrow = 'Admin', children }: DashboardShellProps) => (
+  <div className="flex min-h-screen">
+    <Sidebar />
+    <div className="flex min-w-0 flex-1 flex-col">
+      <header className="flex items-center justify-between gap-4 border-b border-stone-200/70 bg-white px-6 py-4 md:px-8">
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-stone-400">
+            {eyebrow}
+          </p>
+          <h1 className="mt-0.5 truncate text-[18px] font-semibold tracking-[-0.01em] text-stone-900">
+            {title}
+          </h1>
+        </div>
+        <LogoutButton />
+      </header>
+      <main className="flex-1 px-6 py-8 md:px-8">
+        {children}
+      </main>
+    </div>
+  </div>
+);
+
+export default DashboardShell;

--- a/src/app/admin/_components/Sidebar.tsx
+++ b/src/app/admin/_components/Sidebar.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const NAV = [
+  { href: '/admin/subscribers', label: 'Newsletter', icon: '✉' },
+];
+
+const Sidebar = () => {
+  const pathname = usePathname();
+
+  return (
+    <aside className="hidden w-60 shrink-0 border-r border-stone-200/70 bg-white md:flex md:flex-col">
+      <div className="px-5 py-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400">
+          Agility
+        </p>
+        <p className="mt-0.5 text-[15px] font-semibold tracking-[-0.01em] text-stone-900">
+          Admin
+        </p>
+      </div>
+      <nav className="flex-1 px-3 py-2">
+        <ul className="flex flex-col gap-1">
+          {NAV.map((item) => {
+            const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  className={`flex items-center gap-3 rounded-xl px-3 py-2 text-[14px] transition-colors ${
+                    active
+                      ? 'bg-stone-100 font-medium text-stone-900'
+                      : 'text-stone-600 hover:bg-stone-50 hover:text-stone-900'
+                  }`}
+                >
+                  <span aria-hidden className="text-stone-400">{item.icon}</span>
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,18 @@
+import '@/styles/global.css';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Admin — Agility Creative',
+  robots: { index: false, follow: false },
+};
+
+const AdminRootLayout = ({ children }: { children: React.ReactNode }) => (
+  <html lang="pt-BR">
+    <body className="min-h-screen bg-stone-50 font-sans text-stone-900 antialiased">
+      {children}
+    </body>
+  </html>
+);
+
+export default AdminRootLayout;

--- a/src/app/admin/login/LoginForm.tsx
+++ b/src/app/admin/login/LoginForm.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState } from 'react';
+
+const LoginForm = () => {
+  const router = useRouter();
+  const params = useSearchParams();
+  const next = params.get('next') ?? '/admin/subscribers';
+
+  const [user, setUser] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitting) {
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user, password, next }),
+      });
+      if (res.status === 503) {
+        setError('Admin desativado. Configure ADMIN_USER e ADMIN_PASSWORD.');
+        return;
+      }
+      if (!res.ok) {
+        setError('Usuário ou senha inválidos.');
+        return;
+      }
+      const data = (await res.json()) as { next?: string };
+      router.replace(data.next ?? '/admin/subscribers');
+      router.refresh();
+    } catch {
+      setError('Não foi possível entrar. Tente de novo.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[12px] font-medium text-stone-600">Usuário</span>
+        <input
+          type="text"
+          autoComplete="username"
+          required
+          value={user}
+          onChange={e => setUser(e.target.value)}
+          disabled={submitting}
+          className="h-11 rounded-xl border border-stone-200/70 bg-stone-50 px-4 text-[14px] text-stone-900 outline-none transition-colors hover:border-stone-300 focus:border-stone-400 focus:bg-white focus:ring-4 focus:ring-stone-900/5"
+        />
+      </label>
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[12px] font-medium text-stone-600">Senha</span>
+        <input
+          type="password"
+          autoComplete="current-password"
+          required
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          disabled={submitting}
+          className="h-11 rounded-xl border border-stone-200/70 bg-stone-50 px-4 text-[14px] text-stone-900 outline-none transition-colors hover:border-stone-300 focus:border-stone-400 focus:bg-white focus:ring-4 focus:ring-stone-900/5"
+        />
+      </label>
+      {error
+        ? <p className="text-[12px] text-rose-600" role="alert">{error}</p>
+        : null}
+      <button
+        type="submit"
+        disabled={submitting}
+        className="mt-2 inline-flex h-11 items-center justify-center rounded-xl bg-stone-900 px-5 text-[14px] font-medium text-stone-50 transition-colors hover:bg-stone-800 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {submitting ? 'Entrando…' : 'Entrar'}
+      </button>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react';
+
+import LoginForm from './LoginForm';
+
+export const dynamic = 'force-dynamic';
+
+const AdminLoginPage = () => (
+  <main className="flex min-h-screen items-center justify-center bg-stone-50 px-6 py-12">
+    <div className="w-full max-w-sm rounded-2xl border border-stone-200/70 bg-white p-8 shadow-[0_1px_2px_rgba(0,0,0,0.02)]">
+      <div className="mb-6 text-center">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400">
+          Admin
+        </p>
+        <h1 className="mt-1 text-2xl font-semibold tracking-[-0.02em] text-stone-900">
+          Acesso restrito
+        </h1>
+      </div>
+      <Suspense>
+        <LoginForm />
+      </Suspense>
+    </div>
+  </main>
+);
+
+export default AdminLoginPage;

--- a/src/app/admin/subscribers/page.tsx
+++ b/src/app/admin/subscribers/page.tsx
@@ -1,5 +1,6 @@
 import { desc } from 'drizzle-orm';
 
+import DashboardShell from '@/app/admin/_components/DashboardShell';
 import { db } from '@/libs/DB';
 import { blogSubscribersSchema } from '@/models/Schema';
 
@@ -38,40 +39,33 @@ const AdminSubscribersPage = async () => {
     { total: 0, confirmed: 0, pending: 0, unsubscribed: 0 },
   );
 
+  const stats = [
+    { label: 'Total', value: totals.total, tone: 'text-stone-900' },
+    { label: 'Confirmados', value: totals.confirmed, tone: 'text-emerald-700' },
+    { label: 'Pendentes', value: totals.pending, tone: 'text-amber-700' },
+    { label: 'Cancelados', value: totals.unsubscribed, tone: 'text-stone-500' },
+  ];
+
   return (
-    <main className="min-h-screen bg-stone-50 py-12">
-      <div className="mx-auto max-w-6xl px-6">
-        <header className="mb-10">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-400">
-            Admin
-          </p>
-          <h1 className="mt-1 text-3xl font-semibold tracking-[-0.02em] text-stone-900">
-            Newsletter subscribers
-          </h1>
-        </header>
+    <DashboardShell title="Newsletter subscribers" eyebrow="Admin · Newsletter">
+      <section className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {stats.map(stat => (
+          <div
+            key={stat.label}
+            className="rounded-2xl border border-stone-200/70 bg-white p-5"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400">
+              {stat.label}
+            </p>
+            <p className={`mt-2 text-3xl font-semibold tracking-tight ${stat.tone}`}>
+              {stat.value}
+            </p>
+          </div>
+        ))}
+      </section>
 
-        <section className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-4">
-          {([
-            { label: 'Total', value: totals.total, tone: 'text-stone-900' },
-            { label: 'Confirmados', value: totals.confirmed, tone: 'text-emerald-700' },
-            { label: 'Pendentes', value: totals.pending, tone: 'text-amber-700' },
-            { label: 'Cancelados', value: totals.unsubscribed, tone: 'text-stone-500' },
-          ]).map(stat => (
-            <div
-              key={stat.label}
-              className="rounded-2xl border border-stone-200/70 bg-white p-5"
-            >
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-stone-400">
-                {stat.label}
-              </p>
-              <p className={`mt-2 text-3xl font-semibold tracking-tight ${stat.tone}`}>
-                {stat.value}
-              </p>
-            </div>
-          ))}
-        </section>
-
-        <section className="overflow-hidden rounded-2xl border border-stone-200/70 bg-white">
+      <section className="overflow-hidden rounded-2xl border border-stone-200/70 bg-white">
+        <div className="overflow-x-auto">
           <table className="w-full text-left text-[14px]">
             <thead className="bg-stone-50 text-[11px] font-semibold uppercase tracking-[0.12em] text-stone-500">
               <tr>
@@ -116,9 +110,9 @@ const AdminSubscribersPage = async () => {
                   )}
             </tbody>
           </table>
-        </section>
-      </div>
-    </main>
+        </div>
+      </section>
+    </DashboardShell>
   );
 };
 

--- a/src/app/api/admin/login/route.test.ts
+++ b/src/app/api/admin/login/route.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { deriveAdminToken } from '@/libs/adminAuth';
+
+import { POST } from './route';
+
+const buildRequest = (body: unknown) =>
+  new Request('http://localhost/api/admin/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+describe('POST /api/admin/login', () => {
+  const originalUser = process.env.ADMIN_USER;
+  const originalPassword = process.env.ADMIN_PASSWORD;
+
+  beforeEach(() => {
+    process.env.ADMIN_USER = 'admin';
+    process.env.ADMIN_PASSWORD = 'hunter2';
+  });
+
+  afterEach(() => {
+    process.env.ADMIN_USER = originalUser;
+    process.env.ADMIN_PASSWORD = originalPassword;
+  });
+
+  it('returns 503 when ADMIN_USER is missing', async () => {
+    delete process.env.ADMIN_USER;
+    const res = await POST(buildRequest({ user: 'admin', password: 'hunter2' }));
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ error: 'disabled' });
+  });
+
+  it('returns 503 when ADMIN_PASSWORD is missing', async () => {
+    delete process.env.ADMIN_PASSWORD;
+    const res = await POST(buildRequest({ user: 'admin', password: 'hunter2' }));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 400 on invalid JSON body', async () => {
+    const res = await POST(buildRequest('not-json'));
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: 'invalid_request' });
+  });
+
+  it('returns 401 on wrong username', async () => {
+    const res = await POST(buildRequest({ user: 'nope', password: 'hunter2' }));
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: 'invalid_credentials' });
+  });
+
+  it('returns 401 on wrong password', async () => {
+    const res = await POST(buildRequest({ user: 'admin', password: 'wrong' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 + sets cookie + defaults next to /admin/subscribers', async () => {
+    const res = await POST(buildRequest({ user: 'admin', password: 'hunter2' }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, next: '/admin/subscribers' });
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('agility_admin=');
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('SameSite=lax');
+    const expected = await deriveAdminToken('hunter2');
+    expect(setCookie).toContain(`agility_admin=${expected}`);
+  });
+
+  it('honors a safe `next` inside /admin/*', async () => {
+    const res = await POST(
+      buildRequest({ user: 'admin', password: 'hunter2', next: '/admin/another' }),
+    );
+    await expect(res.json()).resolves.toEqual({ ok: true, next: '/admin/another' });
+  });
+
+  it('rejects external `next` to prevent open redirects', async () => {
+    const res = await POST(
+      buildRequest({ user: 'admin', password: 'hunter2', next: 'https://evil.com/' }),
+    );
+    await expect(res.json()).resolves.toEqual({ ok: true, next: '/admin/subscribers' });
+  });
+
+  it('rejects protocol-relative `next` to prevent open redirects', async () => {
+    const res = await POST(
+      buildRequest({ user: 'admin', password: 'hunter2', next: '//evil.com/' }),
+    );
+    await expect(res.json()).resolves.toEqual({ ok: true, next: '/admin/subscribers' });
+  });
+
+  it('rejects non-admin `next`', async () => {
+    const res = await POST(
+      buildRequest({ user: 'admin', password: 'hunter2', next: '/blog' }),
+    );
+    await expect(res.json()).resolves.toEqual({ ok: true, next: '/admin/subscribers' });
+  });
+});

--- a/src/app/api/admin/login/route.ts
+++ b/src/app/api/admin/login/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+
+import { ADMIN_COOKIE_NAME, deriveAdminToken } from '@/libs/adminAuth';
+
+export const runtime = 'nodejs';
+
+const SAFE_NEXT = /^\/admin(?:\/|$)/;
+
+export async function POST(request: Request) {
+  const user = process.env.ADMIN_USER;
+  const password = process.env.ADMIN_PASSWORD;
+  if (!user || !password) {
+    return NextResponse.json({ error: 'disabled' }, { status: 503 });
+  }
+
+  let body: { user?: string; password?: string; next?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+  }
+
+  if (body.user !== user || body.password !== password) {
+    return NextResponse.json({ error: 'invalid_credentials' }, { status: 401 });
+  }
+
+  const token = await deriveAdminToken(password);
+  // Open-redirect guard — never honor a `next` outside `/admin/*`.
+  const next = body.next && SAFE_NEXT.test(body.next) ? body.next : '/admin/subscribers';
+
+  const res = NextResponse.json({ ok: true, next });
+  res.cookies.set(ADMIN_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    // 30 days — long enough to be useful, short enough that a stolen device
+    // can't keep the session forever without re-entering the password.
+    maxAge: 60 * 60 * 24 * 30,
+  });
+  return res;
+}

--- a/src/app/api/admin/logout/route.test.ts
+++ b/src/app/api/admin/logout/route.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { POST } from './route';
+
+describe('POST /api/admin/logout', () => {
+  it('returns 200 and expires the admin cookie', async () => {
+    const res = await POST();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('agility_admin=');
+    expect(setCookie).toContain('Max-Age=0');
+    expect(setCookie).toContain('HttpOnly');
+  });
+});

--- a/src/app/api/admin/logout/route.ts
+++ b/src/app/api/admin/logout/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+import { ADMIN_COOKIE_NAME } from '@/libs/adminAuth';
+
+export const runtime = 'nodejs';
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(ADMIN_COOKIE_NAME, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  return res;
+}

--- a/src/libs/adminAuth.test.ts
+++ b/src/libs/adminAuth.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { ADMIN_COOKIE_NAME, constantTimeEquals, deriveAdminToken } from './adminAuth';
+
+describe('adminAuth', () => {
+  it('exports a stable cookie name', () => {
+    expect(ADMIN_COOKIE_NAME).toBe('agility_admin');
+  });
+
+  it('derives a 64-char hex token from the password', async () => {
+    const token = await deriveAdminToken('hunter2');
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for the same password', async () => {
+    const a = await deriveAdminToken('hunter2');
+    const b = await deriveAdminToken('hunter2');
+    expect(a).toBe(b);
+  });
+
+  it('produces different tokens for different passwords', async () => {
+    const a = await deriveAdminToken('hunter2');
+    const b = await deriveAdminToken('hunter3');
+    expect(a).not.toBe(b);
+  });
+
+  it('constantTimeEquals returns true for identical strings', () => {
+    expect(constantTimeEquals('abc123', 'abc123')).toBe(true);
+  });
+
+  it('constantTimeEquals returns false for different strings of equal length', () => {
+    expect(constantTimeEquals('abc123', 'abc124')).toBe(false);
+  });
+
+  it('constantTimeEquals returns false for strings of different length', () => {
+    expect(constantTimeEquals('abc', 'abc1')).toBe(false);
+  });
+});

--- a/src/libs/adminAuth.ts
+++ b/src/libs/adminAuth.ts
@@ -1,0 +1,45 @@
+// Shared helpers for the admin Basic Auth replacement: a cookie-based session
+// derived from `ADMIN_PASSWORD`. Same security profile as Basic Auth — anyone
+// with the password can mint the cookie, rotating the password invalidates
+// every existing cookie — but with a friendlier sign-in form instead of the
+// browser's native auth prompt.
+
+export const ADMIN_COOKIE_NAME = 'agility_admin';
+
+const TOKEN_SALT = 'agility-admin-v1';
+
+const toHex = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let out = '';
+  for (const byte of bytes) {
+    out += byte.toString(16).padStart(2, '0');
+  }
+  return out;
+};
+
+/**
+ * Cookie value = SHA-256(salt:password). Anyone holding the password can
+ * derive it independently, so the middleware verifies by re-deriving and
+ * constant-time-comparing. Rotating `ADMIN_PASSWORD` invalidates every
+ * existing cookie at the next request.
+ */
+export const deriveAdminToken = async (password: string): Promise<string> => {
+  const encoder = new TextEncoder();
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    encoder.encode(`${TOKEN_SALT}:${password}`),
+  );
+  return toHex(digest);
+};
+
+// Length-equal constant-time compare for token strings.
+export const constantTimeEquals = (a: string, b: string): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,8 @@ import type { NextFetchEvent, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import createMiddleware from 'next-intl/middleware';
 
+import { ADMIN_COOKIE_NAME, constantTimeEquals, deriveAdminToken } from '@/libs/adminAuth';
+
 import { AppConfig } from './utils/AppConfig';
 
 const intlMiddleware = createMiddleware({
@@ -53,36 +55,37 @@ const localizedBlogRedirect = (request: NextRequest) => {
   return null;
 };
 
-// HTTP Basic Auth for /admin/*. Credentials are a shared user/password in
-// env (`ADMIN_USER` / `ADMIN_PASSWORD`) — these pages don't need per-user
-// identity, just a credential gate over operator-only views.
-const adminAuthGate = (request: NextRequest): NextResponse | null => {
-  if (!request.nextUrl.pathname.startsWith('/admin')) {
+// Cookie-based auth for /admin/*. The login page (/admin/login) and its API
+// (/api/admin/login, /api/admin/logout) are public; every other /admin path
+// requires a session cookie whose value matches a token derived from
+// ADMIN_PASSWORD. Rotating the password invalidates every existing cookie.
+const adminAuthGate = async (request: NextRequest): Promise<NextResponse | null> => {
+  const { pathname, search } = request.nextUrl;
+  const isAdminPage = pathname.startsWith('/admin');
+  const isLoginApi = pathname === '/api/admin/login' || pathname === '/api/admin/logout';
+  if (!isAdminPage && !isLoginApi) {
     return null;
   }
-  const user = process.env.ADMIN_USER;
+  if (pathname === '/admin/login' || isLoginApi) {
+    return NextResponse.next();
+  }
   const password = process.env.ADMIN_PASSWORD;
-  if (!user || !password) {
+  if (!process.env.ADMIN_USER || !password) {
     return new NextResponse('Admin disabled — set ADMIN_USER and ADMIN_PASSWORD.', {
       status: 503,
     });
   }
-  const header = request.headers.get('authorization');
-  if (header?.startsWith('Basic ')) {
-    const decoded = atob(header.slice(6));
-    const sep = decoded.indexOf(':');
-    if (sep > 0) {
-      const u = decoded.slice(0, sep);
-      const p = decoded.slice(sep + 1);
-      if (u === user && p === password) {
-        return NextResponse.next();
-      }
+  const cookie = request.cookies.get(ADMIN_COOKIE_NAME)?.value;
+  if (cookie) {
+    const expected = await deriveAdminToken(password);
+    if (constantTimeEquals(cookie, expected)) {
+      return NextResponse.next();
     }
   }
-  return new NextResponse('Authentication required.', {
-    status: 401,
-    headers: { 'WWW-Authenticate': 'Basic realm="admin", charset="UTF-8"' },
-  });
+  const loginUrl = request.nextUrl.clone();
+  loginUrl.pathname = '/admin/login';
+  loginUrl.search = `?next=${encodeURIComponent(pathname + search)}`;
+  return NextResponse.redirect(loginUrl);
 };
 
 // If the visitor previously chose a non-default locale (stored in the
@@ -111,21 +114,23 @@ const localePreferredRedirect = (request: NextRequest) => {
   return NextResponse.redirect(url);
 };
 
-export default function middleware(
+export default async function middleware(
   request: NextRequest,
   event: NextFetchEvent,
 ) {
+  // Admin pages and their auth API are gated by a session cookie and not
+  // localized — handle them before the intl middleware gets a chance to
+  // rewrite the URL. Runs first so the /admin/login bypass works even before
+  // the /api/ early-return below.
+  const adminGate = await adminAuthGate(request);
+  if (adminGate) {
+    return adminGate;
+  }
+
   // API routes carry their own auth (e.g. /api/blog uses bearer token).
   // Don't let next-intl rewrite them to a localized page path.
   if (request.nextUrl.pathname.startsWith('/api/')) {
     return;
-  }
-
-  // Admin pages are gated by Basic Auth and not localized — handle them
-  // before the intl middleware gets a chance to rewrite the URL.
-  const adminGate = adminAuthGate(request);
-  if (adminGate) {
-    return adminGate;
   }
 
   // /en/blog* (and any other non-default locale prefix on /blog) canonicalizes


### PR DESCRIPTION
## Summary
Replaces the browser-native Basic Auth prompt with a proper sign-in page + cookie session, and adds a minimal Tailwind admin shell so future admin pages slot in cleanly.

### New
- `src/app/admin/layout.tsx` — supplies the missing `<html>` / `<body>` for the `/admin/*` subtree (it sits outside `[locale]`, so it never got one before).
- `src/app/admin/login/` — centered card with username + password, posts to `/api/admin/login`, redirects on success.
- `src/app/admin/_components/Sidebar.tsx` + `DashboardShell.tsx` — sidebar with nav links (currently just "Newsletter") plus a topbar with title and "Sair" button. New admin pages: add a `NAV` entry and wrap content in `<DashboardShell title="…">`.
- `src/app/api/admin/login/route.ts` — POST, verifies creds, sets HttpOnly `agility_admin` cookie (SHA-256 of password + salt). Sanitizes `next` against open redirects.
- `src/app/api/admin/logout/route.ts` — POST, clears the cookie.
- `src/libs/adminAuth.ts` — `deriveAdminToken()` (WebCrypto SHA-256, Edge-compatible) + constant-time compare helpers.

### Middleware
- Replaces Basic Auth gate with a cookie check.
- Unauthenticated requests to any `/admin/*` page (except `/admin/login`) redirect to `/admin/login?next=<path>`.
- `/api/admin/login` + `/api/admin/logout` bypass the gate.
- Same 503 if `ADMIN_USER` / `ADMIN_PASSWORD` aren't set.

### Tests (18 new, 161 total — all green)
- `src/libs/adminAuth.test.ts` — token derivation determinism, constant-time compare.
- `src/app/api/admin/login/route.test.ts` — 503 on missing env, 400 on bad JSON, 401 on wrong creds, 200 + cookie on right creds, open-redirect protection (external \`next\`, protocol-relative \`next\`, non-admin \`next\`).
- `src/app/api/admin/logout/route.test.ts` — clears cookie with \`Max-Age=0\`.

## Test plan
- [ ] \`/admin/subscribers\` → redirects to \`/admin/login?next=/admin/subscribers\`.
- [ ] Login with bad creds → form shows "Usuário ou senha inválidos." (no redirect).
- [ ] Login with good creds → lands on \`/admin/subscribers\` with sidebar + topbar.
- [ ] "Sair" → redirected back to \`/admin/login\`, cookie cleared.
- [ ] Other site routes (\`/\`, \`/blog\`, \`/api/blog\`) unchanged.